### PR TITLE
Wmax

### DIFF
--- a/man/simtrial-package.Rd
+++ b/man/simtrial-package.Rd
@@ -18,15 +18,18 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Yilong Zhang \email{elong0527@gmail.com}
+\strong{Maintainer}: Yujie Zhao \email{yujie.zhao@merck.com} [contributor]
 
 Authors:
 \itemize{
   \item Keaven Anderson \email{keaven_anderson@merck.com}
+  \item Yilong Zhang \email{elong0527@gmail.com}
 }
 
 Other contributors:
 \itemize{
+  \item Nan Xiao \email{nan.xiao1@merck.com} [contributor]
+  \item Jianxiao Yang \email{yangjx@ucla.edu} [contributor]
   \item Amin Shirazi \email{ashirazist@gmail.com} [contributor]
   \item Ruixue Wang \email{ruixue.wang@merck.com} [contributor]
   \item Yi Cui \email{yi.cui@merck.com} [contributor]

--- a/man/wMB.Rd
+++ b/man/wMB.Rd
@@ -4,13 +4,17 @@
 \alias{wMB}
 \title{Magirr and Burman Modestly Weighted Logrank Tests}
 \usage{
-wMB(x, delay = 4)
+wMB(x, delay = 4, wmax = Inf)
 }
 \arguments{
 \item{x}{a \code{tensurv}-class \code{tibble} with a counting process dataset}
 
 \item{delay}{The initial delay period where weights increase;
 after this, weights are constant at the final weigh in the delay period}
+
+\item{wmax}{Maximum weight to be returned.
+set \code{delay = Inf, wmax = 2} to be consistent with recommendation of
+Magirr (2021).}
 }
 \value{
 a vector with weights for the Magirr-Burman weighted logrank test
@@ -20,6 +24,8 @@ for the data in \code{x}
 Magirr and Burman (2019) have proposed a weighted logrank test to have better power than
 the logrank test when the treatment effect is delayed, but to still maintain good power under
 a proportional hazards assumption.
+In Magirr (2021), (the equivalent of) a maximum weight was proposed as opposed to a fixed
+time duration over which weights would increase.
 The weights for some early interval specified by the user are the inverse of the combined treatment group
 empirical survival distribution; see details.
 After this initial period, weights are constant at the maximum of the previous weights.
@@ -33,24 +39,36 @@ These weights can then be used to compute a Z-statistic for the modestly weighte
 
 We define \eqn{t^*} to be the input variable \code{delay}.
 This specifies an initial period during which weights increase.
+We also set a maximum weight \eqn{w_max}.
 To define specific weights, we let \eqn{S(t)} denote the Kaplan-Meier survival estimate at time \eqn{t}
 for the combined data (control plus experimental treatment groups).
 The weight at time \eqn{t} is then defined as
-\deqn{w(t)=S(\min(t,t^*))^{-1}.}
+\deqn{w(t)=\min(w_max, S(\min(t,t^*))^{-1}).}
 }
 \examples{
 library(tidyr)
 library(dplyr)
 # Use default enrollment and event rates at cut at 100 events
+# For transparency, may be good to set either `delay` or `wmax` to Inf`
 x <- simPWSurv(n=200) \%>\% cutDataAtCount(125) \%>\% tensurv(txval="Experimental")
-# compute Magirr-Burman weights with
-ZMB <- x \%>\% wMB(6) \%>\%
+# compute Magirr-Burman weights with `delay = 6`
+ZMB <- x \%>\% wMB(6, wmax = Inf) \%>\%
              summarize(S=sum(OminusE*wMB),V=sum(Var*wMB^2),Z=S/sqrt(V))
 # Compute p-value of modestly weighted logrank of Magirr-Burman
 pnorm(ZMB$Z)
+# Now compute with maximum weight of 2 as recommended in Magirr, 2021
+ZMB2 <- x \%>\% wMB(delay = Inf, wmax = 2) \%>\%
+             summarize(S=sum(OminusE*wMB),V=sum(Var*wMB^2),Z=S/sqrt(V))
+# Compute p-value of modestly weighted logrank of Magirr-Burman
+pnorm(ZMB2$Z)
+
 }
 \references{
 Magirr, Dominic, and Carl‐Fredrik Burman.
 "Modestly weighted logrank tests."
-\emph{Statistics in Medicine} 38.20 (2019): 3782-3790.
+\emph{Statistics in Medicine} 38.20 (2019): 3782--3790.
+
+Magirr, Dominic.
+"Non‐proportional hazards in immuno‐oncology: Is an old perspective needed?"
+\emph{Pharmaceutical Statistics} 20.3 (2021): 512--527.
 }

--- a/vignettes/modestWLRTVignette.Rmd
+++ b/vignettes/modestWLRTVignette.Rmd
@@ -4,7 +4,7 @@ output: rmarkdown::html_vignette
 bibliography: simtrial.bib
 vignette: >
   %\VignetteIndexEntry{Using the Magirr-Burman weights for testing}
-  %\VignetteEngine{knitr::rmarkdown} 
+  %\VignetteEngine{knitr::rmarkdown}
 ---
 
 ```{r, include=FALSE}
@@ -27,11 +27,6 @@ options(width = 58)
 They have implemented this in the package [modestWLRT](https://github.com/dominicmagirr/modestWLRT).
 Since the implementation is relatively straightforward, we have added this functionality to the `simtrial` package and explain how to use it here with the `wMB()` function.
 
-We consider two examples:
-
-- A single stratum example where we compare results with the `modestWLRT` package.
-- A stratified example which was not implemented in `modestWLRT`.
-
 Packages used are as follows:
 
 ```{r, message=FALSE, warning=FALSE}
@@ -40,32 +35,30 @@ library(dplyr)
 library(survival)
 ```
 
-## Single stratum examples
-
-### Magirr and Burman delayed effect example
+## Simulating a delayed effect example
 
 First, we specify study duration, sample size and enrollment rates. The enrollment rate is assumed constant during the enrollment period until the targeted sample size is reached.
-For failure rates, we consider the delayed treatment effect example of Magirr and Burman (2019).
-The control group has an exponential failure rate with a median of 15 months. 
+For failure rates, we consider the delayed treatment effect example of @MagirrBurman.
+The control group has an exponential failure rate with a median of 15 months.
 For the initial 6 months, the underlying hazard ratio is one followed by a hazard ratio of 0.7 thereafter.
-This differs from the Magirr and Burman (2019) delayed effect assumptions only in that they assume a hazard ratio of 0.5 after 6 months.
+This differs from the @MagirrBurman delayed effect assumptions only in that they assume a hazard ratio of 0.5 after 6 months.
 
 ```{r, message=FALSE, warning=FALSE}
 studyDuration <- 36
-sampleSize <- 200
+sampleSize <- 300
 enrollRates <- tibble::tibble(duration = 12, rate = 200 / 12)
 failRates <- tibble::tribble(
   ~Stratum, ~duration, ~failRate, ~hr, ~dropoutRate,
   "All", 6, log(2) / 15, 1, 0,
-  "All", 36, log(2) / 15, .7, 0
+  "All", 36, log(2) / 15, .6, 0
 )
 ```
 
 Now we generate a single dataset with the above characteristics and cut data for analysis at 36 months post start of enrollment.
 Then we plot Kaplan-Meier curves for the resulting dataset (red curve for experimental treatment, black for control):
 
-```{r, message=FALSE,warning=FALSE,fig.width=7.5, fig.height=4}
-set.seed(7783)
+```{r, message=FALSE, warning=FALSE, fig.width=7.5, fig.height=4}
+set.seed(7789)
 xpar <- simfix2simPWSurv(failRates)
 MBdelay <- simPWSurv(
   n = sampleSize,
@@ -81,78 +74,61 @@ plot(fit, col = 1:2, mark = "|", xaxt = "n")
 axis(1, xaxp = c(0, 36, 6))
 ```
 
-We perform a logrank and weighted logrank tests as follows:
+## Generalizing the Magirr-Burman test
 
-```{r, message=FALSE, warning=FALSE}
-xx <- MBdelay %>%
-  tensurv(txval = "Experimental") %>%
-  tenFHcorr(rg = tibble(rho = c(0, 0, 1), gamma = c(0, 1, 1))) %>%
-  mutate(p = pnorm(Z))
-xx
-```
+Next, we consider the @Magirr2021 extension of the modestly weighted logrank test (MWLRT) of  @MagirrBurman where we have weights as follows:
 
-Now for a MaxCombo test with the above compoenent tests, we have  p-value of
+$$w(t, \tau, w_{\max}) = \min\left(w_{\max},\left(\frac{1}{S(\min(t,\tau))}\right)\right).$$
 
-```{r, message=FALSE, warning=FALSE}
-xx %>% pMaxCombo()
-```
-
-Next, we consider the Magirr and Burman (2019) modestly weighted logrank test with down-weighting specifid for the first 6 months.
 This requires generating weights and then computing the test.
+We begin with the default of `wmax=\Inf` which corresponds to the original @MagirrBurman test and set the time until maximum weight $\tau$ with `delay = 6`.
 
 ```{r}
 ZMB <- MBdelay %>%
   tensurv(txval = "Experimental") %>%
-  wMB(6) %>%
+  wMB(delay = 6) %>%
   summarize(S = sum(OminusE * wMB), V = sum(Var * wMB^2), Z = S / sqrt(V))
 # Compute p-value of modestly weighted logrank of Magirr-Burman
 pnorm(ZMB$Z)
 ```
 
-Finally, we consider weighted logrank tests with less down-weighting.
-Results are quite similar to the results with greater down-weighting.
+Now we set the maximum weight to be 2 as in @Magirr2021 and set the `delay=Inf` so that the maximum weight begins at the observed median of the observed combined treatment Kaplan-Meier curve.
 
 ```{r}
-xx <- MBdelay %>%
+ZMB <- MBdelay %>%
   tensurv(txval = "Experimental") %>%
-  tenFHcorr(rg = tibble(rho = c(0, 0, .5), gamma = c(0, .5, .5))) %>%
-  mutate(p = pnorm(Z))
-xx
+  wMB(delay = Inf, wmax = 2) %>%
+  summarize(S = sum(OminusE * wMB), V = sum(Var * wMB^2), Z = S / sqrt(V))
+# Compute p-value of modestly weighted logrank of Magirr-Burman
+pnorm(ZMB$Z)
 ```
 
-Check vs tenFH().
+Another way this can be done is with a generalized Fleming-Harrington test with
+
+$$w(t; \rho, \gamma, w_{\max})= \min((1-F(t))^\rho F(t)^\gamma, w_{\max})).$$
+
+and let $\gamma=0, \rho = -1/2.$
 
 ```{r}
-xx <- MBdelay %>%
+wmax <- 2
+Z_modified_FH <- MBdelay %>%
   tensurv(txval = "Experimental") %>%
-  tenFH(rg = tibble(rho = c(0, 0, .5), gamma = c(0, .5, .5)))
-xx
-```
-
-```{r}
-xx <- MBdelay %>%
-  tensurv(txval = "Experimental") %>%
-  tenFHcorr(rg = tibble(rho = c(0, 0, .5, .5), gamma = c(0, .5, .5, 0))) %>%
-  mutate(p = pnorm(Z))
-xx
-```
-
-Now for a MaxCombo test with the above compoenent tests, we have  p-value of
-
-```{r}
-xx %>% pMaxCombo()
+  mutate(w = pmin(wmax, 1 / S)) %>%
+  summarize(S = sum(OminusE * w), V = sum(Var * w^2), Z = S / sqrt(V))
+# Compute p-value of modestly weighted logrank of Magirr-Burman
+pnorm(Z_modified_FH$Z)
 ```
 
 ### Freidlin and Korn strong null hypothesis example
 
 The underlying survival is worse for the experimental group is uniformly worse for the experimental group until the very end of the study.
-This was presented by @FKNPH2019. For this case, we have a hazard ratio of 16 for 1/10 of 1 year (1.2 months), followed by a hazard ratio of 
+This was presented by @FKNPH2019. For this case, we have a hazard ratio of 16 for 1/10 of 1 year (1.2 months), followed by a hazard ratio of
 
 First, we specify study duration, sample size and enrollment rates. The enrollment rate is assumed constant during the enrollment period until the targeted sample size is reached.
-For failure rates, we consider the delayed treatment effect example of Magirr and Burman (2019).
-The control group has an exponential failure rate with a median of 15 months. 
+For failure rates, we consider the delayed treatment effect example of @MagirrBurman.
+The control group has an exponential failure rate with a median of 15 months.
 For the initial 6 months, the underlying hazard ratio is one followed by a hazard ratio of 0.7 thereafter.
-This differs from the Magirr and Burman (2019) delayed effect assumptions only in that they assume a hazard ratio of 0.5 after 6 months.
+This differs from the @MagirrBurman delayed effect assumptions only in that they assume a hazard ratio of 0.5 after 6 months.
 
 ```{r, message=FALSE, warning=FALSE}
 studyDuration <- 5
@@ -188,7 +164,7 @@ plot(fit, col = 1:2, mark = "|", xaxt = "n")
 axis(1, xaxp = c(0, 36, 6))
 ```
 
-We perform a logrank and weighted logrank tests as follows:
+We perform a logrank and weighted logrank tests as suggested for more limited downweighting by follows:
 
 ```{r}
 xx <- FHwn %>%
@@ -198,19 +174,19 @@ xx <- FHwn %>%
 xx
 ```
 
-Now for a MaxCombo test with the above compoenent tests, we have  p-value of
+Now for a MaxCombo test with the above component tests, we have p-value of
 
 ```{r}
 xx %>% pMaxCombo()
 ```
 
-Next, we consider the Magirr and Burman (2019) modestly weighted logrank test with down-weighting specifid for the first 6 months.
+Next, we consider the @MagirrBurman modestly weighted logrank test with down-weighting specified for the first 6 months but a maximum weight of 2.
 This requires generating weights and then computing the test.
 
 ```{r}
 ZMB <- FHwn %>%
   tensurv(txval = "Experimental") %>%
-  wMB(6) %>%
+  wMB(delay = 6, wmax = 2) %>%
   summarize(S = sum(OminusE * wMB), V = sum(Var * wMB^2), Z = S / sqrt(V))
 # Compute p-value of modestly weighted logrank of Magirr-Burman
 pnorm(ZMB$Z)
@@ -227,10 +203,13 @@ xx <- FHwn %>%
 xx
 ```
 
-Now for a MaxCombo test with the above compoenent tests, we have  p-value of
+Now for a MaxCombo test with the above component tests, we have p-value of
 
 ```{r}
 xx %>% pMaxCombo()
 ```
+
+Thus, with less down-weighting the MaxCombo test appears less problematic.
+This is addressed at greater length elsewhere.
 
 ## References

--- a/vignettes/simtrial.bib
+++ b/vignettes/simtrial.bib
@@ -1,193 +1,211 @@
-@article{ChenCCS,
-  title={Multiplicity for a Group Sequential Trial with Biomarker Subpopulations},
-  author={Ting-Yu Chen, Jing Zhao, Linda Sun, Keaven Anderson},
-  pubstate = {submitted},
-  year={2019}
-}
-@article{ding2016subgroup,
-  title={Subgroup mixable inference on treatment efficacy in mixture populations, with an application to time-to-event outcomes},
-  author={Ding, Ying and Lin, Hui-Min and Hsu, Jason C},
-  journal={Statistics in medicine},
-  volume={35},
-  number={10},
-  pages={1580--1594},
-  year={2016},
-  publisher={Wiley Online Library}
-}
 @article{Bretz2009,
-  author="Frank Bretz and Willi Maurer and Martin Posch",
-  title="A graphical approach to sequentially rejective multiple test procedures",
-  journal="Statistics in Medicine",
-  year="2009",
-  volume="28",
-  pages="586-604",
-  doi="10.1002/sim.3495"
-}
-@ARTICLE{MaurerBretz2013,
-author="Willi Maurer and Frank Bretz",
-title="Multiple testing in group sequential trials using graphical approaches",
-journal="Statistics in Biopharmaceutical Research",
-volume="5",
-year="2013",
-pages="311-320",
-DOI="10.1080/19466315.2013.807748"}
-@Manual{gMCP,
-    title = {{gMCP}: Graph Based Multiple Test Procedures},
-    author = {Kornelius Rohmeyer and Florian Klinglmueller},
-    year = {2018},
-    note = {R package version 0.8-14},
-    url = {https://cran.r-project.org/package=gMCP},
-  }
-  @Article{Bretz2011,
-    title = {Graphical approaches for multiple comparison procedures
-      using weighted Bonferroni, Simes or parametric tests},
-    author = {Frank Bretz and Martin Posch and Ekkehard Glimm and
-      Florian Klinglmueller and Willi Maurer and Kornelius Rohmeyer},
-    journal = {Biometrical Journal},
-    year = {2011},
-    publisher = {Wiley},
-    volume = {53},
-    number = {6},
-    pages = {894--913},
-    url =
-      {http://onlinelibrary.wiley.com/doi/10.1002/bimj.201000239/full},
-  }
-@ARTICLE{LachinFoulkes,
-	author = "Lachin, John M. and Foulkes, Mary A.",
-	title = "Evaluation of sample size and power for analyses of survival with allowance for nonuniform patient entry, losses to follow-up, noncompliance, and stratification.",
-	journal = "Biometrics",
-	volume = "42",
-	year = "1986",
-	pages = "507-519"}
-@ARTICLE{Karrison2016,
-    title = {Versatile tests for comparing survival curves based on weighted log-rank statistics},
-    author = {Theodore G Karrison},
-    journal = {Stata Journal},
-    year = {2016},
-    publisher = {Stata Corp},
-    volume = {15},
-    number = {3},
-    pages = {678-690}
+  author  = {Frank Bretz and Willi Maurer and Martin Posch},
+  title   = {A graphical approach to sequentially rejective multiple test procedures},
+  journal = {Statistics in Medicine},
+  year    = {2009},
+  volume  = {28},
+  pages   = {586--604}
 }
 
-@article{Hasegawa2014,
-  title={Sample size determination for the weighted log-rank test with the Fleming--Harrington class of weights in cancer vaccine studies},
-  author={Hasegawa, Takahiro},
-  journal={Pharmaceutical statistics},
-  volume={13},
-  number={2},
-  pages={128--135},
-  year={2014},
-  publisher={Wiley Online Library}
+@article{Bretz2011,
+  title     = {Graphical approaches for multiple comparison procedures using weighted Bonferroni, Simes or parametric tests},
+  author    = {Frank Bretz and Martin Posch and Ekkehard Glimm and Florian Klinglmueller and Willi Maurer and Kornelius Rohmeyer},
+  journal   = {Biometrical Journal},
+  year      = {2011},
+  publisher = {Wiley},
+  volume    = {53},
+  number    = {6},
+  pages     = {894--913}
 }
 
-@article{Xi2017,
-  title={A unified framework for weighted parametric multiple test procedures},
-  author={Xi, Dong and Glimm, Ekkehard and Maurer, Willi and Bretz, Frank},
-  journal={Biometrical Journal},
-  year={2017},
-  publisher={Wiley Online Library}
+@article{ChenCCS,
+  title     = {Multiplicity for a group sequential trial with biomarker subpopulations},
+  author    = {Chen, Ting-Yu and Zhao, Jing and Sun, Linda and Anderson, Keaven M},
+  journal   = {Contemporary Clinical Trials},
+  volume    = {101},
+  pages     = {106249},
+  year      = {2021},
+  publisher = {Elsevier}
 }
 
-@ARTICLE{Tsiatis,
-	author="Anastasios A. Tsiatis",
-	title="Repeated significance testing for a general class of statistics use in censored survival analysis.",
-	journal="Journal of the American Statistical Association",
-	volume="77",
-	pages="855-861",
-	year="1982"}
-
-@ARTICLE{Schemper2009,
-  title="The estimation of average hazard ratios by weighted Cox regression",
-  author="Schemper, Michael and Wakounig, Samo and Heinze, Georg",
-  journal="Statistics in medicine",
-  volume="28",
-  number="19",
-  pages="2473--2489",
-  year="2009"
-}
-
-@ARTICLE{Kalbfleisch1981,
-  title={Estimation of the average hazard ratio},
-  author={Kalbfleisch, John D and Prentice, Ross L},
-  journal={Biometrika},
-  volume={68},
-  number={1},
-  pages={105--112},
-  year={1981}
-}
-
-@UNPUBLISHED{NPHWGDesign,
-  title={Robust design and analysis of clinical trials with non-proportional hazards: a straw man guidance from a cross-pharma working group},
-  author={Satrajit Roychoudhury and Keaven M. Anderson and Jiabu Ye and Pralay Mukhopadhyay},
-  note={Submitted for publication},
-  year={2019}
-}
-
-@UNPUBLISHED{NPHWGSimulation,
-  title={Alternative analysis methods for time to event endpoints under non-proportional hazards: a comparative analysis},
-  author={Ray S. Lin and Ji Lin and Satrajit Roychoudhury and Keaven M. Anderson and Tianle Hu and Bo Huang and Larry F Leon and Jason J.Z. Liao and Rong Liu and Xiaodong Luo and Pralay Mukhopadhyay and Rui Qin and Kay Tatsuoka and Xuejing Wang and Yang Wang and Jian Zhu and Tai-Tsang Chen and Renee Iacona},
-  note={Submitted for publication},
-  year={2019}
-}
-
-@article{Karrison2016,
-  title={Versatile tests for comparing survival curves based on weighted log-rank statistics},
-  author={Karrison, Theodore G},
-  journal={The Stata Journal},
-  volume={16},
-  number={3},
-  pages={678--690},
-  year={2016},
-  publisher={SAGE Publications Sage CA: Los Angeles, CA}
+@article{ding2016subgroup,
+  title     = {Subgroup mixable inference on treatment efficacy in mixture populations, with an application to time-to-event outcomes},
+  author    = {Ding, Ying and Lin, Hui-Min and Hsu, Jason C},
+  journal   = {Statistics in Medicine},
+  volume    = {35},
+  number    = {10},
+  pages     = {1580--1594},
+  year      = {2016},
+  publisher = {Wiley Online Library}
 }
 
 @article{FH1982,
-  title={A class of rank test procedures for censored survival data},
-  author={Harrington, David P and Fleming, Thomas R},
-  journal={Biometrika},
-  volume={69},
-  number={3},
-  pages={553--566},
-  year={1982},
-  publisher={Oxford University Press}
+  title     = {A class of rank test procedures for censored survival data},
+  author    = {Harrington, David P and Fleming, Thomas R},
+  journal   = {Biometrika},
+  volume    = {69},
+  number    = {3},
+  pages     = {553--566},
+  year      = {1982},
+  publisher = {Oxford University Press}
 }
 
 @book{FH2011,
-  title={Counting processes and survival analysis},
-  author={Fleming, Thomas R and Harrington, David P},
-  volume={169},
-  year={2011},
-  publisher={John Wiley \& Sons}
+  title     = {Counting processes and survival analysis},
+  author    = {Fleming, Thomas R and Harrington, David P},
+  volume    = {169},
+  year      = {2011},
+  publisher = {John Wiley \& Sons}
+}
+
+@article{FKNPH2019,
+  title     = {Methods for Accommodating Nonproportional Hazards in Clinical Trials: Ready for the Primary Analysis?},
+  author    = {Freidlin, Boris and Korn, Edward L},
+  journal   = {Journal of Clinical Oncology},
+  volume    = {37},
+  number    = {35},
+  pages     = {3455--3459},
+  year      = {2019},
+  publisher = {American Society of Clinical Oncology}
+}
+
+@manual{gMCP,
+  title  = {{gMCP}: Graph Based Multiple Test Procedures},
+  author = {Kornelius Rohmeyer and Florian Klinglmueller},
+  year   = {2018},
+  note   = {R package version 0.8-14},
+  url    = {https://cran.r-project.org/package=gMCP}
+}
+
+@article{Hasegawa2014,
+  title     = {Sample size determination for the weighted log-rank test with the Fleming--Harrington class of weights in cancer vaccine studies},
+  author    = {Hasegawa, Takahiro},
+  journal   = {Pharmaceutical statistics},
+  volume    = {13},
+  number    = {2},
+  pages     = {128--135},
+  year      = {2014},
+  publisher = {Wiley Online Library}
+}
+
+@article{Kalbfleisch1981,
+  title   = {Estimation of the average hazard ratio},
+  author  = {Kalbfleisch, John D and Prentice, Ross L},
+  journal = {Biometrika},
+  volume  = {68},
+  number  = {1},
+  pages   = {105--112},
+  year    = {1981}
+}
+
+@article{Karrison2016,
+  title     = {Versatile tests for comparing survival curves based on weighted log-rank statistics},
+  author    = {Karrison, Theodore G},
+  journal   = {The Stata Journal},
+  volume    = {16},
+  number    = {3},
+  pages     = {678--690},
+  year      = {2016},
+  publisher = {SAGE Publications Sage CA: Los Angeles, CA}
+}
+
+@article{LachinFoulkes,
+  author  = {Lachin, John M. and Foulkes, Mary A.},
+  title   = {Evaluation of sample size and power for analyses of survival with allowance for nonuniform patient entry, losses to follow-up, noncompliance, and stratification},
+  journal = {Biometrics},
+  volume  = {42},
+  year    = {1986},
+  pages   = {507--519}
 }
 
 @article{Lee2007,
-  title={On the versatility of the combination of the weighted log-rank statistics},
-  author={Lee, Seung-Hwan},
-  journal={Computational Statistics \& Data Analysis},
-  volume={51},
-  number={12},
-  pages={6557--6564},
-  year={2007},
-  publisher={Elsevier}
+  title     = {On the versatility of the combination of the weighted log-rank statistics},
+  author    = {Lee, Seung-Hwan},
+  journal   = {Computational Statistics \& Data Analysis},
+  volume    = {51},
+  number    = {12},
+  pages     = {6557--6564},
+  year      = {2007},
+  publisher = {Elsevier}
 }
+
+@article{Magirr2021,
+  title     = {Non-proportional hazards in immuno-oncology: Is an old perspective needed?},
+  author    = {Magirr, Dominic},
+  journal   = {Pharmaceutical Statistics},
+  volume    = {20},
+  number    = {3},
+  pages     = {512--527},
+  year      = {2021},
+  publisher = {Wiley Online Library}
+}
+
 @article{MagirrBurman,
-  title={Modestly weighted logrank tests},
-  author={Magirr, Dominic and Burman, Carl-Fredrik},
-  journal={Statistics in medicine},
-  volume={38},
-  number={20},
-  pages={3782--3790},
-  year={2019},
-  publisher={Wiley Online Library}
+  title     = {Modestly weighted logrank tests},
+  author    = {Magirr, Dominic and Burman, Carl-Fredrik},
+  journal   = {Statistics in Medicine},
+  volume    = {38},
+  number    = {20},
+  pages     = {3782--3790},
+  year      = {2019},
+  publisher = {Wiley Online Library}
 }
-@article{FKNPH2019,
-  title={Methods for Accommodating Nonproportional Hazards in Clinical Trials: Ready for the Primary Analysis?},
-  author={Freidlin, Boris and Korn, Edward L},
-  journal={Journal of Clinical Oncology},
-  volume={37},
-  number={35},
-  pages={3455--3459},
-  year={2019},
-  publisher={American Society of Clinical Oncology}
+
+@article{MaurerBretz2013,
+  author  = {Willi Maurer and Frank Bretz},
+  title   = {Multiple testing in group sequential trials using graphical approaches},
+  journal = {Statistics in Biopharmaceutical Research},
+  volume  = {5},
+  year    = {2013},
+  pages   = {311--320}
+}
+
+@article{NPHWGDesign,
+  title     = {Robust design and analysis of clinical trials with nonproportional hazards: a straw man guidance from a cross-pharma working group},
+  author    = {Roychoudhury, Satrajit and Anderson, Keaven M and Ye, Jiabu and Mukhopadhyay, Pralay},
+  journal   = {Statistics in Biopharmaceutical Research},
+  pages     = {1--15},
+  year      = {2021},
+  publisher = {Taylor \& Francis}
+}
+
+@article{NPHWGSimulation,
+  title     = {Alternative analysis methods for time to event endpoints under nonproportional hazards: a comparative analysis},
+  author    = {Lin, Ray S and Lin, Ji and Roychoudhury, Satrajit and Anderson, Keaven M and Hu, Tianle and Huang, Bo and Leon, Larry F and Liao, Jason JZ and Liu, Rong and Luo, Xiaodong and others},
+  journal   = {Statistics in Biopharmaceutical Research},
+  volume    = {12},
+  number    = {2},
+  pages     = {187--198},
+  year      = {2020},
+  publisher = {Taylor \& Francis}
+}
+
+@article{Schemper2009,
+  title   = {The estimation of average hazard ratios by weighted Cox regression},
+  author  = {Schemper, Michael and Wakounig, Samo and Heinze, Georg},
+  journal = {Statistics in Medicine},
+  volume  = {28},
+  number  = {19},
+  pages   = {2473--2489},
+  year    = {2009}
+}
+
+@article{Tsiatis,
+  author  = {Anastasios A. Tsiatis},
+  title   = {Repeated significance testing for a general class of statistics use in censored survival analysis},
+  journal = {Journal of the American Statistical Association},
+  volume  = {77},
+  pages   = {855--861},
+  year    = {1982}
+}
+
+@article{Xi2017,
+  title     = {A unified framework for weighted parametric multiple test procedures},
+  author    = {Xi, Dong and Glimm, Ekkehard and Maurer, Willi and Bretz, Frank},
+  journal   = {Biometrical Journal},
+  volume    = {59},
+  number    = {5},
+  pages     = {918--931},
+  year      = {2017},
+  publisher = {Wiley Online Library}
 }


### PR DESCRIPTION
This PR contains these changes written by Keaven:

- Added parameter `wmax` to `wMB()` to cut increasing weights at 50% of combined K-M curve.
- Updated the modest WLRT vignette for Magirr-Burman with maximum up-weighting.
- Added the Magirr (2021) paper to bibliography.

I also sorted and aligned the BibTeX items alphabetically, removed a duplicated item, updated items with latest volume and page information.