### PR TITLE
Test mb_weight() with a stratum with no records

### DIFF
--- a/tests/testthat/test-double_programming_wMB.R
+++ b/tests/testthat/test-double_programming_wMB.R
@@ -59,3 +59,33 @@ test_that("Validation passed for the situation of multiple stratum", {
   out2 <- data.frame(out2[order(out2$stratum, out2$tte), ])
   testthat::expect_equal(out1, out2)
 })
+
+# Test 3: for the situation where a stratum has no records before delay ends ####
+
+test_that("Validation passed for the situation of a stratum with no records", {
+  set.seed(1)
+  x <- sim_pw_surv(
+    n = 200,
+    # 2 stratum,30% and 70% prevalence
+    stratum = tibble::tibble(stratum = c("Low", "High"), p = c(.3, .7)),
+    fail_rate = tibble::tibble(
+      stratum = c(rep("Low", 4), rep("High", 4)),
+      period = rep(1:2, 4),
+      treatment = rep(c(rep("control", 2), rep("experimental", 2)), 2),
+      duration = rep(c(3, 1), 4),
+      rate = c(.03, .05, .03, .03, .05, .08, .07, .04)
+    ),
+    dropout_rate = tibble::tibble(
+      stratum = c(rep("Low", 2), rep("High", 2)),
+      period = rep(1, 4),
+      treatment = rep(c("control", "experimental"), 2),
+      duration = rep(1, 4),
+      rate = rep(.001, 4)
+    )
+  ) %>%
+    cut_data_by_event(125) %>%
+    counting_process(arm = "experimental")
+
+  out <- mb_weight(x, delay = 1)
+  testthat::expect_false(anyNA(out$mb_weight))
+})


### PR DESCRIPTION
Follow up to https://github.com/Merck/simtrial/pull/115#issuecomment-1783231928. I added a test to confirm the new data.table code can handle the situation where a stratum is dropped because it had no records before the delay ends.

I also confirmed the test fails if I comment out the key line:

https://github.com/Merck/simtrial/blob/7daf1e3270f6f4b0f537358f7260f5871be58c0c/R/mb_weight.R#L148-L149