### PR TITLE
Fix backwards compatibility tests

### DIFF
--- a/tests/testthat/generate-backwards-compatible-test-data.R
+++ b/tests/testthat/generate-backwards-compatible-test-data.R
@@ -28,14 +28,22 @@ generate_test_data <- function(
   on.exit(.libPaths(old_lib_paths), add = TRUE)
   on.exit(unlink(tmplib, recursive = TRUE), add = TRUE)
 
+  if ("package:simtrial" %in% search()) {
+    detach("package:simtrial")
+  }
   remotes::install_github(
     repo = "Merck/simtrial",
     ref = reference,
     dependencies = FALSE,
     upgrade = FALSE
   )
-  library("simtrial")
-  packageVersion("simtrial")
+  library("simtrial", lib.loc = .libPaths()[1])
+  observedVersion <- packageVersion("simtrial")
+  expectedVersion <- read.dcf(file.path(tmplib, "simtrial/DESCRIPTION"),
+                              fields = "Version")[1, 1]
+  if (!observedVersion == expectedVersion) {
+    stop("The previous version was not loaded to generate backwards compatibility test data sets")
+  }
   on.exit(detach("package:simtrial"), add = TRUE)
 
   message("Saving output RDS files to ", outdir)
@@ -124,7 +132,7 @@ generate_test_data <- function(
   ex3 <- counting_process(x, arm)
   saveRDS(ex3, file.path(outdir, "counting_process_ex3.rds"))
 
-  # fh_weight() ----------------------------------------------------------------------
+  # wlr() (renamed to fh_weight()) ---------------------------------------------
 
   # Example 1
   # Use default enrollment and event rates at cut at 100 events
@@ -134,11 +142,11 @@ generate_test_data <- function(
   x <- counting_process(x, arm = "experimental")
 
   # Compute the corvariance between FH(0, 0), FH(0, 1) and FH(1, 0)
-  ex1 <- fh_weight(x, rho_gamma = data.frame(rho = c(0, 0, 1), gamma = c(0, 1, 0)))
+  ex1 <- wlr(x, rho_gamma = data.frame(rho = c(0, 0, 1), gamma = c(0, 1, 0)))
   saveRDS(ex1, file.path(outdir, "wlr_ex1.rds"))
-  ex1_var <- fh_weight(x, rho_gamma = data.frame(rho = c(0, 0, 1), gamma = c(0, 1, 0)), return_variance = TRUE)
+  ex1_var <- wlr(x, rho_gamma = data.frame(rho = c(0, 0, 1), gamma = c(0, 1, 0)), return_variance = TRUE)
   saveRDS(ex1_var, file.path(outdir, "wlr_ex1_var.rds"))
-  ex1_cor <- fh_weight(x, rho_gamma = data.frame(rho = c(0, 0, 1), gamma = c(0, 1, 0)), return_corr = TRUE)
+  ex1_cor <- wlr(x, rho_gamma = data.frame(rho = c(0, 0, 1), gamma = c(0, 1, 0)), return_corr = TRUE)
   saveRDS(ex1_cor, file.path(outdir, "wlr_ex1_cor.rds"))
 
   # Example 2
@@ -147,7 +155,7 @@ generate_test_data <- function(
   x <- sim_pw_surv(n = 200)
   x <- cut_data_by_event(x, 100)
   x <- counting_process(x, arm = "experimental")
-  ex2 <- fh_weight(x, rho_gamma = data.frame(rho = c(0, 0), gamma = c(0, 1)), return_corr = TRUE)
+  ex2 <- wlr(x, rho_gamma = data.frame(rho = c(0, 0), gamma = c(0, 1)), return_corr = TRUE)
   saveRDS(ex2, file.path(outdir, "wlr_ex2.rds"))
 
   # rpw_enroll() ---------------------------------------------------------------


### PR DESCRIPTION
I learned from PR #127 (Issue #124) that the backwards compatibility tests aren't currently working as expected. Version 0.3.0 has `wlr()`, not the renamed `fh_weight()`, so `generate-backwards-compatible-test-data.R` should have failed.

The good news is that the backwards compatibility tests are still passing. The problem occurred when I integrated the backwards compatibility tests into the testthat infrastructure, but I had already confirmed they passed before that.