### PR TITLE
Run setDF before returning the data frame

### DIFF
--- a/R/counting_process.R
+++ b/R/counting_process.R
@@ -127,5 +127,6 @@ counting_process <- function(x, arm) {
     n_risk_trt * events * (n_risk_tol - events) /
     n_risk_tol^2 / (n_risk_tol - 1)]
 
-  return(setDF(ans))
+  setDF(ans)
+  return(ans)
 }

--- a/R/cut_data_by_date.R
+++ b/R/cut_data_by_date.R
@@ -39,5 +39,6 @@ cut_data_by_date <- function(x, cut_date) {
   ans[, event := fail * (cte <= cut_date)]
   ans <- ans[, c("tte", "event", "stratum", "treatment")]
 
-  return(setDF(ans))
+  setDF(ans)
+  return(ans)
 }

--- a/R/cut_data_by_event.R
+++ b/R/cut_data_by_event.R
@@ -27,8 +27,6 @@
 #' @return A data frame ready for survival analysis, including columns
 #'   time to event (`tte`), `event`, the `stratum`, and the `treatment`.
 #'
-#' @importFrom data.table setDF
-#'
 #' @export
 #'
 #' @examples
@@ -38,5 +36,5 @@
 cut_data_by_event <- function(x, event) {
   cut_date <- get_cut_date_by_event(x, event)
   ans <- x %>% cut_data_by_date(cut_date = cut_date)
-  return(setDF(ans))
+  return(ans)
 }

--- a/R/fh_weight.R
+++ b/R/fh_weight.R
@@ -226,7 +226,8 @@ fh_weight <- function(
     }
   }
 
-  return(setDF(ans))
+  setDF(ans)
+  return(ans)
 }
 
 # Build an internal function to compute the Z statistics

--- a/R/mb_weight.R
+++ b/R/mb_weight.R
@@ -66,6 +66,8 @@
 #' "Non‐proportional hazards in immuno‐oncology: Is an old perspective needed?"
 #' _Pharmaceutical Statistics_ 20 (3): 512--527.
 #'
+#' @importFrom data.table ":=" as.data.table data.table merge.data.table setDF
+#'
 #' @export
 #'
 #' @examples
@@ -159,4 +161,5 @@ mb_weight <- function(x, delay = 4, w_max = Inf) {
   ans[, max_weight := NULL]
 
   setDF(ans)
+  return(ans)
 }

--- a/R/sim_pw_surv.R
+++ b/R/sim_pw_surv.R
@@ -190,5 +190,6 @@ sim_pw_surv <- function(
   ans[, cte := pmin(dropout_time, fail_time) + enroll_time]
   ans[, fail := (fail_time <= dropout_time) * 1]
 
-  return(setDF(ans))
+  setDF(ans)
+  return(ans)
 }

--- a/R/simfix2simpwsurv.R
+++ b/R/simfix2simpwsurv.R
@@ -120,5 +120,7 @@ simfix2simpwsurv <- function(
   dr <- rbind(dr_control, dr_experimental)
   dr <- dr[, c("stratum", "period", "treatment", "duration", "rate")]
 
-  list(fail_rate = setDF(fr), dropout_rate = setDF(dr))
+  setDF(fr)
+  setDF(dr)
+  return(list(fail_rate = fr, dropout_rate = dr))
 }


### PR DESCRIPTION
Otherwise the object is returned invisibly:

```R
tail(data.table::setDF, 2)                
## 59     invisible(x)
## 60 }
```

This doesn't change the result of the functions. It simply restores the default behavior of printing the object to the console.