### PR TITLE
Update parallel.Rmd to align with CRAN Policies

### DIFF
--- a/vignettes/parallel.Rmd
+++ b/vignettes/parallel.Rmd
@@ -149,11 +149,11 @@ As we vary and increase the number of parameter inputs that we consider, we expe
 To help combat the growing computational burden, we can run these simulations in parallel using the `multisession` backend available to us in `plan()`.
 
 We can adjust the default number of cores with the function `parallelly::availableCores()`.
-The multisession backend will automatically use all available cores by default.
+The multisession backend will automatically use all available cores by default, but here we will use two.
 To initialize our backend, we change our plan.
 
-```{r multisession}
-plan(multisession, workers = availableCores())
+```{r multisession1}
+plan(multisession, workers = 2)
 ```
 
 ## Execution in parallel


### PR DESCRIPTION
Changing the number of workers used by the parallel example to 2 workers. This should align with the [CRAN Policy](https://cran.r-project.org/web/packages/policies.html).

> "If running a package uses multiple threads/cores it must never use more than two simultaneously: the check farm is a shared resource and will typically be running many checks simultaneously."