### PR TITLE
Convert `get_analysis_date()` to data.table

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: simtrial
 Type: Package
 Title: Clinical Trial Simulation
-Version: 0.3.0.4
+Version: 0.3.0.5
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut")),
     person("Yilong", "Zhang", email = "elong0527@gmail.com", role =  c("aut")),

--- a/R/counting_process.R
+++ b/R/counting_process.R
@@ -119,7 +119,7 @@ counting_process <- function(x, arm) {
       events = event,
       n_event_tol = (treatment == arm) * event,
       tte,
-      n_risk_tol ,
+      n_risk_tol,
       n_risk_trt
     )]
   }

--- a/tests/testthat/test-data.table.R
+++ b/tests/testthat/test-data.table.R
@@ -78,6 +78,13 @@ test_that("functions that use data.table do not modify input data table", {
   fh_weight(x)
   expect_identical(x, x_original)
 
+  # get_analysis_date()
+  x <- sim_pw_surv(n = 5)
+  data.table::setDT(x)
+  x_original <- data.table::copy(x)
+  get_analysis_date(x, planned_calendar_time = 1)
+  expect_identical(x, x_original)
+
   # get_cut_date_by_event()
   x <- sim_pw_surv(n = 5)
   data.table::setDT(x)

--- a/tests/testthat/test-data.table.R
+++ b/tests/testthat/test-data.table.R
@@ -102,9 +102,9 @@ test_that("functions that use data.table do not modify input data table", {
   expect_identical(x, x_original)
 
   # rpw_enroll()
-  enroll_rate = data.table::data.table(
-   rate = c(5, 15, 30),
-   duration = c(100, 200, 100)
+  enroll_rate <- data.table::data.table(
+    rate = c(5, 15, 30),
+    duration = c(100, 200, 100)
   )
   data.table::setDT(enroll_rate)
   enroll_rate_original <- data.table::copy(enroll_rate)


### PR DESCRIPTION
In addition to converting to data.table, I made the following changes:

1. Replaced the vectorized logical operators `&` and `|` with their scalar equivalents `&&` and `||` for use in `if` statements
2. Replaced `lapply()` + anonymous functions with `for` loops
3. Styled the package files

The speed improvement is as expected:

```R
library("simtrial")
library("microbenchmark")
n <- 500
x <- sim_pw_surv(n = n)
microbenchmark(
  get_analysis_date = get_analysis_date(
    x,
    min_n_overall = n * 0.8,
    min_n_per_stratum = c(200, NA),
    min_followup = 12
  )
)

# before

## Unit: milliseconds
##               expr    min     lq     mean median     uq     max neval
##  get_analysis_date 6.7069 7.9107 11.24213 8.5425 9.4881 209.134   100

# after

## Unit: milliseconds
##               expr    min     lq     mean median      uq     max neval
##  get_analysis_date 1.8519 2.1588 2.557967 2.4057 2.63095 10.2379   100
```