### PR TITLE
Convert early_zero_weight() to data.table

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: simtrial
 Type: Package
 Title: Clinical Trial Simulation
-Version: 0.3.0.5
+Version: 0.3.0.6
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut")),
     person("Yilong", "Zhang", email = "elong0527@gmail.com", role =  c("aut")),

--- a/R/early_zero_weight.R
+++ b/R/early_zero_weight.R
@@ -26,6 +26,8 @@
 #' @return A data frame. The column `weight` contains the weights for the
 #'   early zero weighted logrank test for the data in `x`.
 #'
+#' @importFrom data.table ":=" as.data.table merge.data.table setDF
+#'
 #' @export
 #'
 #' @references
@@ -90,38 +92,31 @@
 #'   early_zero_weight(early_period = 2, fail_rate = fail_rate) %>%
 #'   filter(row_number() %in% seq(5, 200, 40))
 early_zero_weight <- function(x, early_period = 4, fail_rate = NULL) {
-  n_stratum <- length(unique((x$stratum)))
+  ans <- as.data.table(x)
+  n_stratum <- length(unique(ans$stratum))
 
   # If it is unstratified design
   if (n_stratum == 1) {
-    ans <- x %>%
-      mutate(weight = case_when(
-        tte < early_period ~ 0,
-        tte >= early_period ~ 1
-      ))
+    ans[, weight := ifelse(tte < early_period, 0, 1)]
   } else {
     if (is.null(fail_rate)) {
       stop("For stratified design to use `early_zero_weight()`, `fail_rate` can't be `NULL`.")
     }
-    if (!all((fail_rate %>% group_by(stratum) %>% summarise(x = n() == 2))$x)) {
+    fail_rate <- as.data.table(fail_rate)
+    # require 2 piece failure rate per stratum
+    two_piece_fr <- fail_rate[, .(check = .N == 2), by = "stratum"]
+    if (!all(two_piece_fr$check)) {
       stop("`early_zero_weight()` only allows delayed treatment effect, that is, 2 piece failure rate with HR = 1 at the first period.")
     }
 
-    late_hr <- fail_rate %>%
-      filter(hr != 1) %>%
-      select(stratum, hr)
-    delay_change_time <- fail_rate %>%
-      filter(hr == 1) %>%
-      select(stratum, duration)
+    late_hr <- fail_rate[hr != 1, .(stratum, hr)]
+    delay_change_time <- fail_rate[hr == 1, .(stratum, duration)]
 
-    ans <- x %>%
-      left_join(late_hr) %>%
-      left_join(delay_change_time) %>%
-      mutate(weight = case_when(
-        tte < duration ~ 0,
-        tte >= duration ~ hr
-      ))
+    ans <- merge.data.table(ans, late_hr, by = "stratum", all.x = TRUE)
+    ans <- merge.data.table(ans, delay_change_time, by = "stratum", all.x = TRUE)
+    ans[, weight := ifelse(tte < duration, 0, hr)]
   }
 
-  ans
+  setDF(ans)
+  return(ans)
 }

--- a/R/global.R
+++ b/R/global.R
@@ -55,7 +55,8 @@ utils::globalVariables(
     "time",
     "treatment",
     "tte",
-    "var_o_minus_e"
+    "var_o_minus_e",
+    "weight"
   )
 )
 

--- a/tests/testthat/test-unvalidated-early_zero_weight.R
+++ b/tests/testthat/test-unvalidated-early_zero_weight.R
@@ -1,5 +1,3 @@
-library(dplyr)
-
 test_that("early_zero_weight() with unstratified data", {
   # Example 1: Unstratified
   set.seed(123)
@@ -60,3 +58,57 @@ test_that("early_zero_weight() with stratified data", {
   expect_equal(observed, expected)
 })
 
+test_that("early_zero_weight() fails with bad input", {
+  # Example 2: Stratified
+  n <- 500
+  # Two strata
+  stratum <- c("Biomarker-positive", "Biomarker-negative")
+  prevelance_ratio <- c(0.6, 0.4)
+  # Enrollment rate
+  enroll_rate <- gsDesign2::define_enroll_rate(
+    stratum = rep(stratum, each = 2),
+    duration = c(2, 10, 2, 10),
+    rate = c(c(1, 4) * prevelance_ratio[1], c(1, 4) * prevelance_ratio[2])
+  )
+  enroll_rate$rate <- enroll_rate$rate * n / sum(enroll_rate$duration * enroll_rate$rate)
+  # Failure rate
+  med_pos <- 10 # Median of the biomarker positive population
+  med_neg <- 8 # Median of the biomarker negative population
+  hr_pos <- c(1, 0.7) # Hazard ratio of the biomarker positive population
+  hr_neg <- c(1, 0.8) # Hazard ratio of the biomarker negative population
+  fail_rate <- gsDesign2::define_fail_rate(
+    stratum = rep(stratum, each = 2),
+    duration = c(3, 1000, 4, 1000),
+    fail_rate = c(log(2) / c(med_pos, med_pos, med_neg, med_neg)),
+    hr = c(hr_pos, hr_neg),
+    dropout_rate = 0.01
+  )
+  # Simulate data
+  temp <- simfix2simpwsurv(fail_rate) # Convert the failure rate
+  set.seed(2023)
+  input <- sim_pw_surv(
+    n = n, # Sample size
+    # Stratified design with prevalence ratio of 6:4
+    stratum = data.frame(stratum = stratum, p = prevelance_ratio),
+    # Randomization ratio
+    block = c("control", "control", "experimental", "experimental"),
+    enroll_rate = enroll_rate, # Enrollment rate
+    fail_rate = temp$fail_rate, # Failure rate
+    dropout_rate = temp$dropout_rate # Dropout rate
+  )
+  input <- cut_data_by_event(input, 125)
+  input <- counting_process(input, arm = "experimental")
+
+  # missing fail_rate
+  expect_error(
+    early_zero_weight(input, early_period = 2),
+    "For stratified design to use `early_zero_weight\\(\\)`, `fail_rate` can't be `NULL`."
+  )
+
+  # not a 2 piece failure rate
+  fail_rate_incomplete <- fail_rate[-1, ]
+  expect_error(
+    early_zero_weight(input, early_period = 2, fail_rate = fail_rate_incomplete),
+    "`early_zero_weight\\(\\)` only allows delayed treatment effect, that is, 2 piece failure rate with HR = 1 at the first period."
+  )
+})


### PR DESCRIPTION
Please merge PR #143 first. I will likely need to resolve some merge conflicts locally before we can merge this one

I also added some more tests

The speed increase for the unstratified case was limited (~1200 -> 800 microseconds). However, the speed increase for the stratified case was impressive (~123 -> ~5 milliseconds)

Some lessons learned:

* For a single column, `length(unique(x$col))` is noticeably faster than `uniqueDT(x[, .(col)])`, as least for small tables (nrow = 125 in this case). I assume that `uniqueDT()` pays off when the number of rows increases, and also when multiple columns need to be selected, but I didn't investigate thoroughly
* `merge.data.table(x, y, by = "col", all.x = TRUE)` matches the sort order of `dplyr::left_join(x, y)`, whereas `x[y, on = "col"]` returns a different row order