### PR TITLE
Replace stringr functions with base R equivalents

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,7 +59,6 @@ Suggests:
     markdown,
     remotes,
     rmarkdown,
-    stringr,
     survMisc,
     testthat,
     tidyr

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,5 +1,4 @@
 library(testthat)
-library(stringr)
 library(simtrial)
 
 test_check("simtrial")

--- a/tests/testthat/helper-string.R
+++ b/tests/testthat/helper-string.R
@@ -1,0 +1,10 @@
+# A replacement for stringr::str_count()
+str_count <- function(x, pattern, fixed = TRUE) {
+  loc <- gregexpr(pattern, text = x, fixed = fixed)
+  unlist(lapply(loc, function(x) length(x[x > 0])))
+}
+
+# A replacement for stringr::str_detect()
+str_detect <- function(x, pattern) {
+  grepl(pattern, x = x)
+}

--- a/tests/testthat/test-double_programming_sim_pw_surv.R
+++ b/tests/testthat/test-double_programming_sim_pw_surv.R
@@ -37,13 +37,13 @@ bktest1 <- c()
 j <- 1
 for (i in seq(1, floor(nrow(block1) / 4))) {
   j <- 4 * i - 3
-  bktest1[i] <- sum(stringr::str_count(block1$treatment[j:(j + 3)], "control"))
+  bktest1[i] <- sum(str_count(block1$treatment[j:(j + 3)], "control"))
 }
 j <- 1
 bktest2 <- 0
 for (i in seq(1, floor(nrow(block2) / 4))) {
   j <- 4 * i - 3
-  bktest2[i] <- sum(stringr::str_count(block2$treatment[j:(j + 3)], "control"))
+  bktest2[i] <- sum(str_count(block2$treatment[j:(j + 3)], "control"))
 }
 
 # prepare to test fail_rate
@@ -62,8 +62,8 @@ testthat::test_that("stratum percentage calculated from simulated dataset must b
                     the tolerance=0.002 of stratum in setup (0.4,0.6)", {
   expect_equal(
     object = c(
-      sum(stringr::str_count(x$stratum, "Low")) / 400000,
-      sum(stringr::str_count(x$stratum, "High")) / 400000
+      sum(str_count(x$stratum, "Low")) / 400000,
+      sum(str_count(x$stratum, "High")) / 400000
     ),
     expected = c(0.4, 0.6), tolerance = 0.002
   )

--- a/tests/testthat/test-independent_test_simfix2simpwsurv.R
+++ b/tests/testthat/test-independent_test_simfix2simpwsurv.R
@@ -27,11 +27,11 @@ testthat::test_that("stratgum values must be the same and stratum length must be
 })
 
 testthat::test_that("treatment after converting contains only control and experimental with the right length", {
-  testthat::expect_equal(length(fail_rate$stratum), sum(stringr::str_detect(failRatesPWSurv$treatment, "control")))
-  testthat::expect_equal(length(fail_rate$stratum), sum(stringr::str_detect(failRatesPWSurv$treatment, "experimental")))
+  testthat::expect_equal(length(fail_rate$stratum), sum(str_detect(failRatesPWSurv$treatment, "control")))
+  testthat::expect_equal(length(fail_rate$stratum), sum(str_detect(failRatesPWSurv$treatment, "experimental")))
   testthat::expect_equal(length(failRatesPWSurv$treatment), length(fail_rate$stratum) * 2)
-  testthat::expect_equal(length(fail_rate$stratum), sum(stringr::str_detect(dropoutRatesPWSurv$treatment, "control")))
-  testthat::expect_equal(length(fail_rate$stratum), sum(stringr::str_detect(dropoutRatesPWSurv$treatment, "experimental")))
+  testthat::expect_equal(length(fail_rate$stratum), sum(str_detect(dropoutRatesPWSurv$treatment, "control")))
+  testthat::expect_equal(length(fail_rate$stratum), sum(str_detect(dropoutRatesPWSurv$treatment, "experimental")))
   testthat::expect_equal(length(dropoutRatesPWSurv$treatment), length(fail_rate$stratum) * 2)
 })
 


### PR DESCRIPTION
Fixes #147.

This PR replaces the stringr functions with their base R equivalents, and removes stringr from `Suggests`.