### PR TITLE
Remove markdown and remotes from `Suggests`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,8 +56,6 @@ Suggests:
     gsDesign,
     gsDesign2,
     knitr,
-    markdown,
-    remotes,
     rmarkdown,
     stringr,
     survMisc,


### PR DESCRIPTION
This PR removes markdown and remotes from `Suggests`.

remotes was introduced in https://github.com/Merck/simtrial/commit/04b36d068e4a3b9b6a8a6c739fa9576be2a556fc for comparing data.table results to a previous dplyr-based version of simtrial in tests. Since the test has been removed in https://github.com/Merck/simtrial/pull/135, remotes is not needed anymore.

markdown was introduced in https://github.com/Merck/simtrial/commit/2118701f73eb63cd35ced3e415df4f4e42a0a3ea for unknown reasons. It is not used anywhere.