### PR TITLE
Cleanup ignore files

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,12 +1,11 @@
-^\.github$
 ^.*\.Rproj$
 ^\.Rproj\.user$
-^LICENSES_THIRD_PARTY$
-^_pkgdown\.yml$
 ^\.gitattributes$
+^\.github$
+^codecov\.yml$
+^_pkgdown\.yml$
 ^pkgdown$
+^docs$
+^data-raw$
 ^LICENSE$
 ^LICENSES_THIRD_PARTY$
-^codecov\.yml$
-^doc$
-^data-raw$

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,6 @@
 .Rproj.user
-doc
-docs
-Meta
-inst/doc
-.Rprofile
 .Rhistory
 .RData
 .Ruserdata
-tests/testthat/fixtures/backwards-compatibility
+inst/doc
+docs


### PR DESCRIPTION
This PR cleans up `.gitignore` and `.Rbuildignore` by removing the superfluous rules and reordering the lists.