### PR TITLE
Use `preset: "bootstrap"` in pkgdown

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -5,6 +5,7 @@ url: https://merck.github.io/simtrial/
 template:
   bootstrap: 5
   bslib:
+    preset: "bootstrap"
     primary: "#00857c"
     navbar-light-brand-color: "#fff"
     navbar-light-brand-hover-color: "#fff"


### PR DESCRIPTION
This PR sets `preset` to `"bootstrap"` in `_pkgdown.yml` explicitly, to avoid the theming changes due to bslib 0.6.0 (released 2023-11-21) changing the default of `preset` to `"shiny"`.

For more context, see https://github.com/r-lib/pkgdown/issues/2376.