### PR TITLE
Improve Roxygen docs and fix linting issues

### DIFF
--- a/R/counting_process.R
+++ b/R/counting_process.R
@@ -24,6 +24,7 @@
 #' at risk count and count of events at the specified tte
 #' sorted by stratum and tte.
 #'
+#' @details
 #' The function only considered two group situation.
 #'
 #' The tie is handled by the Breslow's Method.
@@ -43,7 +44,6 @@
 #' is at risk in both treatment group and control group.
 #' Other variables in this represent the following within each stratum at
 #' each time at which one or more events are observed:
-#'
 #' - `events`: Total number of events
 #' - `n_event_tol`: Total number of events at treatment group
 #' - `n_risk_tol`: Number of subjects at risk
@@ -121,7 +121,6 @@ counting_process <- function(x, arm) {
       n_risk_trt
     )]
   }
-
 
   # Keep calculation for observed time with at least one event,
   # at least one subject is at risk in both treatment group and control group.

--- a/R/fh_weight.R
+++ b/R/fh_weight.R
@@ -214,11 +214,11 @@ fh_weight <- function(
 
     if (return_corr) {
       corr_mat <- stats::cov2cor(cov_mat)
-      colnames(corr_mat) <- paste("v", 1:ncol(corr_mat), sep = "")
+      colnames(corr_mat) <- paste("v", seq_len(ncol(corr_mat)), sep = "")
       ans <- cbind(rho_gamma, z, as.data.frame(corr_mat))
     } else if (return_variance) {
       corr_mat <- cov_mat
-      colnames(corr_mat) <- paste("v", 1:ncol(corr_mat), sep = "")
+      colnames(corr_mat) <- paste("v", seq_len(ncol(corr_mat)), sep = "")
       ans <- cbind(rho_gamma, z, as.data.frame(corr_mat))
     } else if (return_corr + return_corr == 0) {
       corr_mat <- NULL
@@ -243,7 +243,7 @@ wlr_z_stat <- function(x, rho_gamma, return_variance) {
     ans$var <- rep(0, nrow(rho_gamma))
   }
 
-  for (i in 1:nrow(rho_gamma)) {
+  for (i in seq_len(nrow(rho_gamma))) {
     weight <- xx$s^rho_gamma$rho[i] * (1 - xx$s)^rho_gamma$gamma[i]
     weighted_o_minus_e <- weight * xx$o_minus_e
     weighted_var <- weight^2 * xx$var_o_minus_e

--- a/R/fit_pwexp.R
+++ b/R/fit_pwexp.R
@@ -95,7 +95,7 @@ fit_pwexp <- function(
   times <- c(0, cumsum(intervals))
 
   ans <- NULL
-  for (i in 1:length(intervals)) {
+  for (i in seq_along(length(intervals))) {
     dat <- subset(xx, time > times[i])
     dat$status[dat$time > times[i + 1]] <- 0
     dat$time[dat$time > times[i + 1]] <- times[i + 1]

--- a/R/fit_pwexp.R
+++ b/R/fit_pwexp.R
@@ -95,7 +95,7 @@ fit_pwexp <- function(
   times <- c(0, cumsum(intervals))
 
   ans <- NULL
-  for (i in seq_along(length(intervals))) {
+  for (i in seq_along(intervals)) {
     dat <- subset(xx, time > times[i])
     dat$status[dat$time > times[i + 1]] <- 0
     dat$time[dat$time > times[i + 1]] <- times[i + 1]

--- a/R/mb_weight.R
+++ b/R/mb_weight.R
@@ -18,19 +18,6 @@
 
 #' Magirr and Burman modestly weighted logrank tests
 #'
-#' Magirr and Burman (2019) proposed a weighted logrank test to have better
-#' power than the logrank test when the treatment effect is delayed,
-#' but to still maintain good power under a proportional hazards assumption.
-#' In Magirr (2021), (the equivalent of) a maximum weight was proposed
-#' as opposed to a fixed time duration over which weights would increase.
-#' The weights for some early interval specified by the user are the inverse
-#' of the combined treatment group empirical survival distribution; see details.
-#' After this initial period, weights are constant at the maximum of the
-#' previous weights. Another advantage of the test is that under strong
-#' null hypothesis that the underlying survival in the control group is
-#' greater than or equal to underlying survival in the experimental group,
-#' Type I error is controlled as the specified level.
-#'
 #' Computes Magirr-Burman weights and adds them to a dataset created by
 #' [counting_process()].
 #' These weights can then be used to compute a z-statistic for the
@@ -48,6 +35,19 @@
 #'   Magirr-Burman weighted logrank test for the data in `x`.
 #'
 #' @details
+#' Magirr and Burman (2019) proposed a weighted logrank test to have better
+#' power than the logrank test when the treatment effect is delayed,
+#' but to still maintain good power under a proportional hazards assumption.
+#' In Magirr (2021), (the equivalent of) a maximum weight was proposed
+#' as opposed to a fixed time duration over which weights would increase.
+#' The weights for some early interval specified by the user are the inverse
+#' of the combined treatment group empirical survival distribution; see details.
+#' After this initial period, weights are constant at the maximum of the
+#' previous weights. Another advantage of the test is that under strong
+#' null hypothesis that the underlying survival in the control group is
+#' greater than or equal to underlying survival in the experimental group,
+#' Type I error is controlled as the specified level.
+#'
 #' We define \eqn{t^*} to be the input variable `delay`.
 #' This specifies an initial period during which weights increase.
 #' We also set a maximum weight \eqn{w_{\max}}.

--- a/R/sim_fixed_n.R
+++ b/R/sim_fixed_n.R
@@ -201,7 +201,7 @@ sim_fixed_n <- function(
     stop("sim_fixed_n: stratum in `sim_fixed_n()` must be the same in stratum and fail_rate.")
   }
 
-  if (any(is.na(match(stratum$stratum, stratum2))) | any(is.na(match(stratum2, stratum$stratum)))) {
+  if (any(is.na(match(stratum$stratum, stratum2))) || any(is.na(match(stratum2, stratum$stratum)))) {
     stop("sim_fixed_n: stratum in `sim_fixed_n()` must be the same in stratum and fail_rate.")
   }
 

--- a/inst/logo/logo-main.R
+++ b/inst/logo/logo-main.R
@@ -9,7 +9,7 @@ num_lines <- 3000
 r_vals <- seq(0.04, 2, by = 0.1)
 circles_list <- list()
 
-for (i in 1:length(r_vals)) {
+for (i in seq_along(r_vals)) {
   r <- r_vals[i]
   circle <- data.frame(len = seq(0, 2 * pi, length.out = num_lines))
   circle$x <- r * sin(circle$len)

--- a/man/mb_weight.Rd
+++ b/man/mb_weight.Rd
@@ -22,6 +22,12 @@ A data frame. The column \code{mb_weight} contains the weights for the
 Magirr-Burman weighted logrank test for the data in \code{x}.
 }
 \description{
+Computes Magirr-Burman weights and adds them to a dataset created by
+\code{\link[=counting_process]{counting_process()}}.
+These weights can then be used to compute a z-statistic for the
+modestly weighted logrank test proposed.
+}
+\details{
 Magirr and Burman (2019) proposed a weighted logrank test to have better
 power than the logrank test when the treatment effect is delayed,
 but to still maintain good power under a proportional hazards assumption.
@@ -34,12 +40,6 @@ previous weights. Another advantage of the test is that under strong
 null hypothesis that the underlying survival in the control group is
 greater than or equal to underlying survival in the experimental group,
 Type I error is controlled as the specified level.
-}
-\details{
-Computes Magirr-Burman weights and adds them to a dataset created by
-\code{\link[=counting_process]{counting_process()}}.
-These weights can then be used to compute a z-statistic for the
-modestly weighted logrank test proposed.
 
 We define \eqn{t^*} to be the input variable \code{delay}.
 This specifies an initial period during which weights increase.

--- a/man/rpwexp.Rd
+++ b/man/rpwexp.Rd
@@ -23,7 +23,7 @@ or a treatment effect that that is otherwise changing
 (for example, decreasing) over time.
 \code{rpwexp()} is to support simulation of both the Lachin and Foulkes (1986)
 sample size method for (fixed trial duration) as well as the
-Kim and Tsiatis(1990) method (fixed enrollment rates and either
+Kim and Tsiatis (1990) method (fixed enrollment rates and either
 fixed enrollment duration or fixed minimum follow-up);
 see \code{\link[gsDesign:nSurv]{gsDesign::nSurv()}}.
 }

--- a/tests/testthat/test-double_programming_fit_pwexp.R
+++ b/tests/testthat/test-double_programming_fit_pwexp.R
@@ -1,24 +1,24 @@
 test_fit_pwexp <- function(Srv, intervals) {
   time <- Surv[, "time"]
   status <- Surv[, "status"]
-  if (tail(time, 1) > sum(intervals) & tail(status, 1) == 1) intervals <- c(intervals, Inf)
+  if (tail(time, 1) > sum(intervals) && tail(status, 1) == 1) intervals <- c(intervals, Inf)
   out <- NULL
   interval.start <- 0
   interval.end <- 0
-  for (i in 1:length(intervals)) {
+  for (i in seq_along(length(intervals))) {
     if (i == length(intervals)) {
       interval.start <- 0
     } else {
       interval.start <- interval.start + intervals[i - 1]
     }
-    interval.end <- interval.end + interals[i]
+    interval.end <- interval.end + intervals[i]
     datai <- Srv[Srv[, "time"] > interval.start]
     if (nrow(datai) == 0) next
     datai[datai[, "time"] > interval.end][, "time"] <- interval.end
     datai[, "time"] <- datai[, "time"] - interval.start
     events <- sum(datai[, "status"])
     TTOT <- sum(datai[, "times"])
-    out <- rbind(out, data.fram(intervals = interval.end, TTOT = TTOT, events = evetns, rate = events / TTOT, m2ll = 2 * (rate * TTOT - events * log(rate))))
+    out <- rbind(out, data.frame(intervals = interval.end, TTOT = TTOT, events = events, rate = events / TTOT, m2ll = 2 * (rate * TTOT - events * log(rate))))
   }
 
   return(out)

--- a/tests/testthat/test-double_programming_fit_pwexp.R
+++ b/tests/testthat/test-double_programming_fit_pwexp.R
@@ -5,7 +5,7 @@ test_fit_pwexp <- function(Srv, intervals) {
   out <- NULL
   interval.start <- 0
   interval.end <- 0
-  for (i in seq_along(length(intervals))) {
+  for (i in seq_along(intervals)) {
     if (i == length(intervals)) {
       interval.start <- 0
     } else {

--- a/tests/testthat/test-double_programming_simfix.R
+++ b/tests/testthat/test-double_programming_simfix.R
@@ -54,7 +54,7 @@ testthat::test_that("test for events in the correct directions in timing_type=3 
   tt2test <- subset(test2, test2$cut == "Targeted events", select = c(event, ln_hr, z, duration, sim))
   tt3test <- subset(test2, test2$cut == "Minimum follow-up", select = c(event, ln_hr, z, duration, sim))
   ttvalue <- 0
-  for (i in 1:nrow(tt3test)) {
+  for (i in seq_len(nrow(tt3test))) {
     if ((tt3test$duration[i] > tt2test$duration[i]) & (tt3test$event[i] >= tt2test$event[i])) {
       ttvalue[i] <- 1
     } else if ((tt3test$duration[i] <= tt2test$duration[i]) & (tt3test$event[i] <= tt2test$event[i])) {
@@ -71,7 +71,7 @@ testthat::test_that("test for timing_type=4 outputs using timing_type 1 and 2 ou
   tt2test <- subset(test2, test2$cut == "Targeted events", select = c(event, ln_hr, z, duration, sim))
   tt4test <- subset(test2, test2$cut == "Max(planned duration, event cut)", select = c(event, ln_hr, z, duration, sim))
   tt4event <- 0
-  for (i in 1:nrow(tt4test)) {
+  for (i in seq_len(nrow(tt4test))) {
     if (tt1test$duration[i] < tt2test$duration[i]) {
       tt4event[i] <- tt2test$event[i]
     } else {
@@ -87,7 +87,7 @@ testthat::test_that("test for timing_type=5 outputs using timing_type 2 and 3 ou
   tt3test <- subset(test2, test2$cut == "Minimum follow-up", select = c(event, ln_hr, z, duration, sim))
   tt5test <- subset(test2, test2$cut == "Max(min follow-up, event cut)", select = c(event, ln_hr, z, duration, sim))
   tt5event <- 0
-  for (i in 1:nrow(tt5test)) {
+  for (i in seq_len(nrow(tt5test))) {
     if (tt2test$duration[i] < tt3test$duration[i]) {
       tt5event[i] <- tt3test$event[i]
     } else {

--- a/tests/testthat/test-independent_test_pvalue_maxcombo.R
+++ b/tests/testthat/test-independent_test_pvalue_maxcombo.R
@@ -28,7 +28,7 @@ testthat::test_that("the p-values correspond to pvalue_maxcombo", {
   wt1 <- c(list(a0 = c(0, 0)), wt)
   combo.wt <- combn(wt1, 2)
   combo.wt.list <- list()
-  for (i in 1:ncol(combo.wt)) {
+  for (i in seq_len(ncol(combo.wt))) {
     combo.wt.list[[i]] <- combo.wt[, i]
   }
   combo.wt.list.up <- lapply(combo.wt.list, function(a) {

--- a/tests/testthat/test-independent_test_simfix2simpwsurv.R
+++ b/tests/testthat/test-independent_test_simfix2simpwsurv.R
@@ -41,12 +41,12 @@ testthat::test_that("Duration values match before and after converting and in ri
 })
 
 testthat::test_that("fail_rate match before and after converting and are in right length ", {
-  testthat::expect_equal(fail_rate$fail_rate, failRatesPWSurv$rate[1:length(fail_rate$fail_rate)])
+  testthat::expect_equal(fail_rate$fail_rate, failRatesPWSurv$rate[seq_along(fail_rate$fail_rate)])
   testthat::expect_equal(fail_rate$fail_rate * fail_rate$hr, failRatesPWSurv$rate[(length(fail_rate$fail_rate) + 1):(length(fail_rate$fail_rate) * 2)])
 })
 
 testthat::test_that("dropout_rate match before and after converting and are in right length ", {
-  testthat::expect_equal(fail_rate$dropout_rate, dropoutRatesPWSurv$rate[1:length(fail_rate$dropout_rate)])
+  testthat::expect_equal(fail_rate$dropout_rate, dropoutRatesPWSurv$rate[seq_along(fail_rate$dropout_rate)])
   testthat::expect_equal(fail_rate$dropout_rate, dropoutRatesPWSurv$rate[(length(fail_rate$fail_rate) + 1):(length(fail_rate$fail_rate) * 2)])
 })
 

--- a/tests/testthat/test-independent_test_wlr.R
+++ b/tests/testthat/test-independent_test_wlr.R
@@ -54,7 +54,7 @@ testthat::test_that("fh_weight calculated correct correlation value when input a
   wt1 <- c(list(a0 = c(0, 0)), wt)
   combo.wt <- combn(wt1, 2)
   combo.wt.list <- list()
-  for (i in 1:ncol(combo.wt)) {
+  for (i in seq_len(ncol(combo.wt))) {
     combo.wt.list[[i]] <- combo.wt[, i]
   }
   combo.wt.list.up <- lapply(combo.wt.list, function(a) {


### PR DESCRIPTION
This PR:

- Improves Roxygen documentation section clarity in two functions.
- Fixes the main (true positive) R code linting issues seen by running:

  ```r
  lints <- lintr::lint_package()
  lints[sapply(lints, `[[`, "type") %in% c("error", "warning")]
  ```

  to ensure best practice.