### PR TITLE
Update news for simtrial 0.3.1 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,9 +25,9 @@ Description: Provides some basic routines for simulating a
     generate trial simulations for trials with time to event outcomes.
     Piecewise exponential failure rates and piecewise constant
     enrollment rates are the underlying mechanism used to simulate
-    a broad range of scenarios. However, the basic generation of data
-    is done using pipes to allow maximum flexibility for users to
-    meet different needs.
+    a broad range of scenarios such as those presented in
+    Lin et al. (2020) <doi:10.1080/19466315.2019.1697738>.
+    However, the basic generation of data is done using pipes to allow maximum flexibility for users to meet different needs.
 License: GPL-3
 URL: https://merck.github.io/simtrial/, https://github.com/Merck/simtrial
 BugReports: https://github.com/Merck/simtrial/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,8 @@ Description: Provides some basic routines for simulating a
     enrollment rates are the underlying mechanism used to simulate
     a broad range of scenarios such as those presented in
     Lin et al. (2020) <doi:10.1080/19466315.2019.1697738>.
-    However, the basic generation of data is done using pipes to allow maximum flexibility for users to meet different needs.
+    However, the basic generation of data is done using pipes to allow
+    maximum flexibility for users to meet different needs.
 License: GPL-3
 URL: https://merck.github.io/simtrial/, https://github.com/Merck/simtrial
 BugReports: https://github.com/Merck/simtrial/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: simtrial
 Type: Package
 Title: Clinical Trial Simulation
-Version: 0.3.0.10
+Version: 0.3.1
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut")),
     person("Yilong", "Zhang", email = "elong0527@gmail.com", role =  c("aut")),

--- a/LICENSE
+++ b/LICENSE
@@ -632,7 +632,7 @@ state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
     simtrial: Clinical Trial Simulation
-    Copyright (c) 2022 Merck & Co., Inc., Rahway, NJ, USA and its affiliates. All rights reserved.
+    Copyright (c) 2023 Merck & Co., Inc., Rahway, NJ, USA and its affiliates. All rights reserved.
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    simtrial  Copyright (c) 2022 Merck & Co., Inc., Rahway, NJ, USA and its affiliates. All rights reserved.
+    simtrial  Copyright (c) 2023 Merck & Co., Inc., Rahway, NJ, USA and its affiliates. All rights reserved.
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,18 +1,77 @@
-# simtrial 0.2.0, August, 2020
+# simtrial 0.3.1
 
-- Updated vignettes and web site
-- Prepared for Regulatory/Industry Training session in September
+## Significant user-visible changes
 
-# simtrial 0.1.7.9004, February, 2020
+- API: function names, argument names changed.
+  We recommend to checking out the
+  [function reference page](https://merck.github.io/simtrial/reference/)
+  to see the latest naming scheme and search the merged
+  [pull requests](https://github.com/Merck/simtrial/pulls?q=is%3Apr+is%3Aclosed)
+  to see detailed change history
+  (thanks, @LittleBeannie, @lili-ling-msd, @XintongLi2023).
+- Dataset names are updated.
 
-- Added wMB() to compute Magirr-Burman weights
-- Added vignette to demonstrate working with different weighting schemes
-- Replaced Depends with Imports in DESCRIPTION
+## Improvements
 
-# simtrial 0.1.7.9003, November, 2019
+- The table backend has been rewritten to use data.table for
+  optimal computational performance. On average, 3x to 5x speedup can be
+  observed compared to the previous implementation
+  (thanks, @jdblischak, #111).
+- Use `%dofuture%` to follow modern standard (thanks, @cmansch, #77).
+- `rpwexp()` inverse CDF method, naive method implementations unexported
+  as internal functions (#174).
+  The C++ implementation is from #15 (thanks, @jianxiaoyang).
 
-- Incorporated new functions to simplify use (simfix, simfix2simPWSurv, pMaxCombo)
-- Removed hgraph with intent to put it into a release of gsDesign
-- Limited to 2 essential vignettes
-- Added continuous integration/continuous deployment (yaml) and pkgdown for web site development
-- Limited dependencies to those that are essential; this removed some convenience functions not related to core package functionality
+## New features
+
+- New function `early_zero_weight()` is added as a weighting function
+  for early data removal (thanks, @LittleBeannie, #123).
+- New function `get_analysis_date()` is added to enable the calculation
+  of interim/final analysis dates based on various conditions
+  (thanks, @LittleBeannie, #122).
+
+## Documentation
+
+- Add a vignette to demonstrate the parallelization workflow and
+  coding best practices (thanks, @cmansch, #113 and #134).
+
+## Bug fixes
+
+# simtrial 0.2.2
+
+GitHub release in February 2023.
+
+This is the version that enables parallel computation in `simfix()`.
+
+# simtrial 0.2.1
+
+GitHub release in May 2022.
+
+This version supports the _Biometrical Journal_ paper
+"A unified framework for weighted parametric group sequential design (WPGSD)"
+by Keaven M. Anderson, Zifang Guo, Jing Zhao, and Linda Z. Sun.
+
+# simtrial 0.2.0
+
+Internal development release in August 2020.
+
+- Updated vignettes and website.
+- Prepared for Regulatory/Industry training session in September.
+
+# simtrial 0.1.7.9004
+
+Internal development release in February 2020.
+
+- Added `wMB()` to compute Magirr-Burman weights.
+- Added vignette to demonstrate working with different weighting schemes.
+- Replaced `Depends` with `Imports` in `DESCRIPTION`.
+
+# simtrial 0.1.7.9003
+
+Internal development release in November 2019.
+
+- Incorporated new functions to simplify use (`simfix()`, `simfix2simPWSurv()`, `pMaxCombo()`).
+- Removed `hgraph()` with intent to put it into a release of gsDesign.
+- Limited to 2 essential vignettes.
+- Added continuous integration/continuous deployment (YAML) and pkgdown for website generation.
+- Limited dependencies to those that are essential; this removed some convenience functions not related to core package functionality.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,41 +1,53 @@
 # simtrial 0.3.1
 
+This release introduces significant changes to the API, improves simulation
+performance substantially, and adds new features and documentation.
+
 ## Significant user-visible changes
 
-- API: function names, argument names changed.
-  We recommend to checking out the
-  [function reference page](https://merck.github.io/simtrial/reference/)
-  to see the latest naming scheme and search the merged
-  [pull requests](https://github.com/Merck/simtrial/pulls?q=is%3Apr+is%3Aclosed)
-  to see detailed change history
-  (thanks, @LittleBeannie, @lili-ling-msd, @XintongLi2023).
-- Dataset names are updated.
+- Complete overhaul of the API. Function and argument names now use
+  snake case for consistency and readability. See the
+  [function reference](https://merck.github.io/simtrial/reference/)
+  for the updated naming scheme. Detailed change history is available in the
+  [merged pull requests](https://github.com/Merck/simtrial/pulls?q=is%3Apr+is%3Aclosed)
+  (thanks, @LittleBeannie, @lili-ling-msd, and @XintongLi2023).
+- Dataset names updated to snake case (thanks, @nanxstats, #164).
+- The base pipe operator is now used throughout the package.
+  The magrittr pipe is no longer re-exported (thanks, @nanxstats, #146).
 
 ## Improvements
 
-- The table backend has been rewritten to use data.table for
-  optimal computational performance. On average, 3x to 5x speedup can be
-  observed compared to the previous implementation
+- Rewritten table backend for simtrial functions using data.table,
+  achieving a 3x to 5x speedup compared to the previous implementation
   (thanks, @jdblischak, #111).
-- Use `%dofuture%` to follow modern standard (thanks, @cmansch, #77).
-- `rpwexp()` inverse CDF method, naive method implementations unexported
-  as internal functions (#174).
-  The C++ implementation is from #15 (thanks, @jianxiaoyang).
+- `sim_fixed_n()` now utilizes the `%dofuture%` operator for parallelization,
+  enhancing flexibility and reproducibility (thanks, @cmansch, #110).
+- `rpwexp()` adopts the inverse CDF method for random number generation,
+  with the naive methods now as internal functions
+  (thanks, @jianxiaoyang, #15 and #174).
+- `sim_fixed_n()` is optimized to skip Breslow's method in the absence of ties
+  (thanks, @jdblischak, #130).
+- The internal function for computing Z statistics in Fleming-Harrington
+  weighted logrank tests is now named `wlr_z_stat()` (thanks, @elong0527, #105).
 
 ## New features
 
-- New function `early_zero_weight()` is added as a weighting function
-  for early data removal (thanks, @LittleBeannie, #123).
-- New function `get_analysis_date()` is added to enable the calculation
-  of interim/final analysis dates based on various conditions
-  (thanks, @LittleBeannie, #122).
+- `early_zero_weight()` is added as a weighting function for early data removal
+  (thanks, @LittleBeannie, #123).
+- `get_analysis_date()` is added to calculate interim/final analysis dates
+  under various conditions (thanks, @LittleBeannie, #122).
 
 ## Documentation
 
-- Add a vignette to demonstrate the parallelization workflow and
+- New `vignette("workflow")` providing an overview of data manipulations
+  involved in TTE simulations (thanks, @keaven, #99).
+- New `vignette("parallel")` demonstrating the parallelization workflow and
   coding best practices (thanks, @cmansch, #113 and #134).
 
-## Bug fixes
+## Miscellaneous
+
+- Added a hex sticker logo with a generative art design for the package
+  (thanks, @keaven, #158).
 
 # simtrial 0.2.2
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,17 @@ for time-to-event endpoints.
 
 ## Installation
 
-You can install from GitHub:
+The easiest way to get simtrial is to install from CRAN:
 
 ```r
+install.packages("simtrial")
+```
+
+Alternatively, to use a new feature or get a bug fix,
+you can install the development version of simtrial from GitHub:
+
+```r
+# install.packages("remotes")
 remotes::install_github("Merck/simtrial")
 ```
 

--- a/man/simtrial-package.Rd
+++ b/man/simtrial-package.Rd
@@ -8,7 +8,7 @@
 \description{
 \if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
-Provides some basic routines for simulating a clinical trial. The primary intent is to provide some tools to generate trial simulations for trials with time to event outcomes. Piecewise exponential failure rates and piecewise constant enrollment rates are the underlying mechanism used to simulate a broad range of scenarios. However, the basic generation of data is done using pipes to allow maximum flexibility for users to meet different needs.
+Provides some basic routines for simulating a clinical trial. The primary intent is to provide some tools to generate trial simulations for trials with time to event outcomes. Piecewise exponential failure rates and piecewise constant enrollment rates are the underlying mechanism used to simulate a broad range of scenarios such as those presented in Lin et al. (2020) \doi{10.1080/19466315.2019.1697738}. However, the basic generation of data is done using pipes to allow maximum flexibility for users to meet different needs.
 }
 \seealso{
 Useful links:

--- a/tests/testthat/test-independent_test_rpwexp_inverse_cdf_cpp.R
+++ b/tests/testthat/test-independent_test_rpwexp_inverse_cdf_cpp.R
@@ -1,6 +1,6 @@
 test_that("rpwexp_inverse_cdf_cpp handles 0 fail_rate for final period", {
   # 0 failure rate for last period
-  s <- simtrial:::rpwexp_inverse_cdf_cpp(
+  s <- rpwexp_inverse_cdf_cpp(
     n = 100,
     fail_rate = data.frame(duration = c(0, 2), rate = c(5, 0))
   )
@@ -10,7 +10,7 @@ test_that("rpwexp_inverse_cdf_cpp handles 0 fail_rate for final period", {
 
 testthat::test_that("rpwexp_inverse_cdf_cpp handles 0 fail rate properly for one period", {
   # 0 failure rate
-  s <- simtrial:::rpwexp_inverse_cdf_cpp(
+  s <- rpwexp_inverse_cdf_cpp(
     n = 100,
     fail_rate = data.frame(duration = c(1), rate = c(0))
   )
@@ -21,7 +21,7 @@ testthat::test_that("rpwexp_inverse_cdf_cpp handles 0 fail rate properly for one
 
 testthat::test_that("rpwexp_inverse_cdf_cpp handles 0 fail rate properly for multiple periods", {
   # 0 failure rate for 1st period (with duration of 1 time unit)
-  s <- simtrial:::rpwexp_inverse_cdf_cpp(
+  s <- rpwexp_inverse_cdf_cpp(
     n = 100,
     fail_rate = data.frame(duration = c(1, 2), rate = c(0, 5))
   )


### PR DESCRIPTION
This PR updates `NEWS.md` for simtrial 0.3.1 release.

Also extends the installation section to include CRAN installation guide in `README.md`.

Besides, I fixed a few minor but potential issues per [extrachecks](https://github.com/DavisVaughan/extrachecks), such as

- Add a reference to the description field in `DESCRIPTION`.
- Avoid using `:::` in tests.
- Update copyright year in `LICENSE`.