### PR TITLE
Add `@return` to `rpwexp()`

### DIFF
--- a/R/rpwexp.R
+++ b/R/rpwexp.R
@@ -39,6 +39,8 @@
 #'   specified in `duration`. The final interval is extended to be infinite
 #'   to ensure all observations are generated.
 #'
+#' @return The generated random numbers.
+#'
 #' @export
 #'
 #' @examples

--- a/man/rpwexp.Rd
+++ b/man/rpwexp.Rd
@@ -14,6 +14,9 @@ rpwexp(n = 100, fail_rate = data.frame(duration = c(1, 1), rate = c(10, 20)))
 specified in \code{duration}. The final interval is extended to be infinite
 to ensure all observations are generated.}
 }
+\value{
+The generated random numbers.
+}
 \description{
 The piecewise exponential distribution allows a simple method to specify
 a distribution where the hazard rate changes over time.


### PR DESCRIPTION
This PR adds `@return` to `rpwexp()` so all exported functions have their return value documented, besides `@examples`.

This fulfills the extrachecks rule.