### PR TITLE
Wrap > 5 sec examples in `\donttest{}`

### DIFF
--- a/R/sim_fixed_n.R
+++ b/R/sim_fixed_n.R
@@ -85,6 +85,7 @@
 #' # Example with 2 tests: logrank and FH(0,1)
 #' sim_fixed_n(n_sim = 1, rho_gamma = data.frame(rho = 0, gamma = c(0, 1)))
 #'
+#' \donttest{
 #' # Example 3
 #' # Power by test
 #' # Only use cuts for events, events + min follow-up
@@ -116,12 +117,13 @@
 #'
 #' mean(p < .025)
 #'
-#' # Example 3
+#' # Example 4
 #' # Use two cores
 #' set.seed(2023)
 #' plan("multisession", workers = 2)
 #' sim_fixed_n(n_sim = 10)
 #' plan("sequential")
+#' }
 sim_fixed_n <- function(
     n_sim = 1000,
     sample_size = 500, # Sample size

--- a/man/sim_fixed_n.Rd
+++ b/man/sim_fixed_n.Rd
@@ -93,6 +93,7 @@ sim_fixed_n(n_sim = 3)
 # Example with 2 tests: logrank and FH(0,1)
 sim_fixed_n(n_sim = 1, rho_gamma = data.frame(rho = 0, gamma = c(0, 1)))
 
+\donttest{
 # Example 3
 # Power by test
 # Only use cuts for events, events + min follow-up
@@ -124,10 +125,11 @@ p <- xx |>
 
 mean(p < .025)
 
-# Example 3
+# Example 4
 # Use two cores
 set.seed(2023)
 plan("multisession", workers = 2)
 sim_fixed_n(n_sim = 10)
 plan("sequential")
+}
 }


### PR DESCRIPTION
This PR wraps > 5 sec examples of `sim_fixed_n()` in `\donttest{}` following the rule in extrachecks.

This > 5 sec note on `sim_fixed_n()` have shown up in the GitHub Actions checks, so I think it's likely exceeding the 5 second limit on the CRAN build machines, too.