### PR TITLE
Options and write path

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: simtrial
 Type: Package
 Title: Clinical Trial Simulation
-Version: 0.3.1
+Version: 0.3.2
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut")),
     person("Yilong", "Zhang", email = "elong0527@gmail.com", role =  c("aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# simtrial 0.3.2
+
+This release makes minor improvements on auxiliary code with side-effects.
+
+## Improvements
+
+- Remove the code that sets `options()` within `vignette("modest-wlrt")`.
+- Updated the code used for generating image assets. These scripts now write to
+  `tempdir()` instead of the package directory.
+
 # simtrial 0.3.1
 
 This release introduces significant changes to the API, improves simulation

--- a/inst/logo/logo-main.R
+++ b/inst/logo/logo-main.R
@@ -51,7 +51,7 @@ dots <- ggplot() +
   )
 
 ggsave(
-  "inst/logo/logo-main.png",
+  file.path(tempdir(), "logo-main.png"),
   device = ragg::agg_png,
   scale = 4, width = 256 * 2, height = 256 * 2,
   units = "px", dpi = 300

--- a/vignettes/modest-wlrt.Rmd
+++ b/vignettes/modest-wlrt.Rmd
@@ -12,8 +12,6 @@ knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>"
 )
-
-options(width = 58)
 ```
 
 ## Introduction

--- a/vignettes/workflow.Rmd
+++ b/vignettes/workflow.Rmd
@@ -105,5 +105,5 @@ digraph boxes_and_diamonds {
 }
 ")
 
-rsvg::rsvg_png(charToRaw(DiagrammeRsvg::export_svg(g)), file = "vignettes/workflow.png")
+rsvg::rsvg_png(charToRaw(DiagrammeRsvg::export_svg(g)), file = file.path(tempdir(), "workflow.png"))
 ```


### PR DESCRIPTION
This PR fixes the two CRAN review comments regarding

- Resetting `options()` after use.
- Not writing to package or home directory.