### PR TITLE
Remove the skip() of the multitest() test

### DIFF
--- a/tests/testthat/test-unvalidated-multitest.R
+++ b/tests/testthat/test-unvalidated-multitest.R
@@ -7,7 +7,6 @@ test_that("multitest() is equivalent to running tests individually", {
   rmst_partial <- create_test(rmst, tau = 20)
   maxcombo_partial <- create_test(maxcombo, rho = c(0, 0), gamma = c(0, 0.5))
 
-  skip('skip')
   observed <- multitest(
     data = trial_data_cut,
     wlr = wlr_partial,


### PR DESCRIPTION
The single `mutlitest()` test was skipped in PR #237. It passes locally for me. This PR removes the `skip()` to restore the test.