### PR TITLE
Fixing sim_fixed_n() parallel results return

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: simtrial
 Type: Package
 Title: Clinical Trial Simulation
-Version: 0.4.1.3
+Version: 0.4.1.4
 Authors@R: c(
     person("Keaven", "Anderson", email = "keaven_anderson@merck.com", role = c("aut")),
     person("Yujie", "Zhao", email = "yujie.zhao@merck.com", role =  c("ctb","cre")),

--- a/R/sim_fixed_n.R
+++ b/R/sim_fixed_n.R
@@ -252,7 +252,7 @@ sim_fixed_n <- function(
   results <- foreach::foreach(
     i = seq_len(n_sim),
     .combine = "rbind",
-    .errorhandling = "pass",
+    .errorhandling = "stop",
     .options.future = list(seed = TRUE)
   ) %dofuture% {
     # Generate piecewise data ----
@@ -369,11 +369,9 @@ sim_fixed_n <- function(
 
     results_sim <- rbindlist(addit)
     results_sim[, sim := i]
-    setDF(results_sim)
-    results <- rbind(results, results_sim)
-    # return(results_sim)
+    results_sim
   }
-
+  setDF(results)
   return(results)
 }
 

--- a/vignettes/parallel.Rmd
+++ b/vignettes/parallel.Rmd
@@ -31,6 +31,8 @@ The function `sim_fixed_n()` provides a simulation workflow for a two-arm trial 
 We can vary the parameters of the trial using different functions outlined in the documentation.
 This function now provides users the opportunity to implement their simulations using the previously described parallel backends to accelerate the computation.
 
+The function `sim_gs_n()` which simulates group sequential designs under a fixed sample size also supports the use of user-defined backends to parallelize simulations in a similar manner. 
+
 ## Background
 
 Without specifying a backend, `sim_fixed_n()` will execute sequentially.


### PR DESCRIPTION
This update addresses two open issues: https://github.com/Merck/simtrial/issues/250 and https://github.com/Merck/simtrial/issues/251. 

In order to return the results from each `%dofuture%` loop, the last object must return some value. The `setDF()` call previously used resulted in the results not being passed back from the loop when run with a parallel backend. This error was hidden in the results as the loop used the `.errorhandling = "pass"` instead of `"stop"`. 

The parallel vignette was also updated to indicate that `sim_gs_n()` supports the same backend implementation as `sim_fixed_n()`. 