### PR TITLE
Fixing Bug for Cut Functions in Parallel

### DIFF
--- a/R/sim_gs_n.R
+++ b/R/sim_gs_n.R
@@ -271,7 +271,6 @@ sim_gs_n <- function(
   ans <- foreach::foreach(
     sim_id = seq_len(n_sim),
     test = replicate(n=n_sim, expr=test, simplify = FALSE),
-    cut = replicate(n=n_sim, expr=cut, simplify = FALSE),
     .combine = "rbind",
     .errorhandling = "stop",
     .options.future = list(seed = TRUE)
@@ -361,6 +360,7 @@ sim_gs_n <- function(
 #' # Cut the trial data
 #' cutting(trial_data)
 create_cut <- function(...) {
+  lapply(X = list(...), FUN = fo)
   function(data) {
     get_analysis_date(data, ...)
   }

--- a/R/sim_gs_n.R
+++ b/R/sim_gs_n.R
@@ -360,7 +360,7 @@ sim_gs_n <- function(
 #' # Cut the trial data
 #' cutting(trial_data)
 create_cut <- function(...) {
-  lapply(X = list(...), FUN = fo)
+  lapply(X = list(...), FUN = force)
   function(data) {
     get_analysis_date(data, ...)
   }

--- a/R/sim_gs_n.R
+++ b/R/sim_gs_n.R
@@ -271,6 +271,7 @@ sim_gs_n <- function(
   ans <- foreach::foreach(
     sim_id = seq_len(n_sim),
     test = replicate(n=n_sim, expr=test, simplify = FALSE),
+    cut = replicate(n=n_sim, expr=cut, simplify = FALSE),
     .combine = "rbind",
     .errorhandling = "stop",
     .options.future = list(seed = TRUE)


### PR DESCRIPTION
Cut functions that use globals were not resolving due to a lazy evaluation within a foreach/doFuture framework. The solution is to force the `create_cut` function to evaluate its arguments. 
Addresses #260. 
Pull request has a single line of code updated from previous versions to fix. 