### PR TITLE
Test and document forced evaluation of promises for parallel execution

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,5 +63,6 @@ Suggests:
     tidyr
 LinkingTo:
     Rcpp
+Remotes: Merck/gsDesign2
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -64,4 +64,4 @@ Suggests:
 LinkingTo:
     Rcpp
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/R/sim_gs_n.R
+++ b/R/sim_gs_n.R
@@ -222,6 +222,7 @@
 #'   test = list(ia1 = ia1_test, ia2 = ia2_test, fa = fa_test),
 #'   cut = list(ia1 = ia1_cut, ia2 = ia2_cut, fa = fa_cut)
 #' )
+#' }
 #'
 #' # Example 9: regular logrank test at all 3 analyses in parallel
 #' plan("multisession", workers = 2)
@@ -235,7 +236,6 @@
 #'   weight = fh(rho = 0, gamma = 0)
 #' )
 #' plan("sequential")
-#' }
 sim_gs_n <- function(
     n_sim = 1000,
     sample_size = 500,
@@ -360,7 +360,9 @@ sim_gs_n <- function(
 #' # Cut the trial data
 #' cutting(trial_data)
 create_cut <- function(...) {
+  # Force evaluation of input arguments (required for parallel computing)
   lapply(X = list(...), FUN = force)
+
   function(data) {
     get_analysis_date(data, ...)
   }

--- a/man/sim_gs_n.Rd
+++ b/man/sim_gs_n.Rd
@@ -242,6 +242,7 @@ sim_gs_n(
   test = list(ia1 = ia1_test, ia2 = ia2_test, fa = fa_test),
   cut = list(ia1 = ia1_cut, ia2 = ia2_cut, fa = fa_cut)
 )
+}
 
 # Example 9: regular logrank test at all 3 analyses in parallel
 plan("multisession", workers = 2)
@@ -255,6 +256,5 @@ sim_gs_n(
   weight = fh(rho = 0, gamma = 0)
 )
 plan("sequential")
-}
 \dontshow{\}) # examplesIf}
 }


### PR DESCRIPTION
Follow-up to PR #261 

I converted the example from Issue #260 into a test. It's a very frustrating test case though. I could only get it to fail pre-#261 when running the code interactively (though it did also fail via `Rscript`). When I ran it via `R CMD check`, it always passed. Unclear why, but I suspect that {testthat} may be responsible.

I also moved the parallel example of `sim_gs_n()` outside of `\dontrun{}`. This was added in https://github.com/Merck/simtrial/commit/749eadcca8d95b2fc3df50653b92274783020c95
(https://github.com/Merck/simtrial/pull/249), and at least when I run `R CMD check` locally, there is no problem with executing this code.