### PR TITLE
Update navbar style for pkgdown 2.1.0

### DIFF
--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -1,6 +1,5 @@
 /* navbar background */
-.bg-light,
-.navbar-light {
+nav.bg-light {
     background-color: #00857c !important;
 }
 
@@ -10,11 +9,16 @@
 }
 
 /* navbar link status */
-.navbar-light .navbar-nav .nav-item>.nav-link:hover {
+nav.bg-light .navbar-nav .nav-item.active .nav-link {
+    color: #212529;
+    background-color: #e9ecef;
+}
+
+nav.bg-light .navbar-nav .nav-item>.nav-link:hover {
     background: #005c55;
 }
 
-.navbar-light .navbar-nav .nav-item.active>.nav-link:hover {
+nav.bg-light .navbar-nav .nav-item.active>.nav-link:hover {
     color: #fff;
 }
 


### PR DESCRIPTION
This PR updates the navbar link style in `extra.css` to accommodate the HTML class name changes in pkgdown 2.1.0 (due to the new option to have light/dark themes).

This would restore the navbar look and feel under pkgdown < 2.1.0. Without this change, when rendering with pkgdown 2.1.0, the navbar link hover and active state color contrast will be too low.