### PR TITLE
Use getFromNamespace instead of ::: to fix S3 dispatch for as_gt()

### DIFF
--- a/R/as_gt.R
+++ b/R/as_gt.R
@@ -148,10 +148,12 @@ as_gt.simtrial_gs_wlr <- function(x,
 
 #' @export
 as_gt.fixed_design <- function(x, ...) {
-  gsDesign2:::as_gt.fixed_design(x, ...)
+  f <- utils::getFromNamespace("as_gt.fixed_design", "gsDesign2")
+  f(x, ...)
 }
 
 #' @export
 as_gt.gs_design <- function(x, ...) {
-  gsDesign2:::as_gt.gs_design(x, ...)
+  f <- utils::getFromNamespace("as_gt.gs_design", "gsDesign2")
+  f(x, ...)
 }


### PR DESCRIPTION
Avoid `R CMD check` NOTE about accessing internal functions between packages we maintain (in this case {gsDesign2})

xref: https://github.com/Merck/simtrial/issues/284, https://github.com/Merck/simtrial/pull/287, https://github.com/Merck/gsDesign2/issues/490, https://github.com/Merck/gsDesign2/pull/492