### PR TITLE
Move {gsDesign2} to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,14 +46,14 @@ Imports:
     mvtnorm,
     stats,
     survival,
-    utils,
-    gsDesign2 (>= 1.1.3)
+    utils
 Suggests:
     Matrix,
     covr,
     dplyr,
     ggplot2,
     gsDesign,
+    gsDesign2 (>= 1.1.3),
     gt,
     knitr,
     rmarkdown,


### PR DESCRIPTION
Follow-up to #301

Removes the following NOTE from `R CMD check`:

```R
❯ checking dependencies in R code ... NOTE
  Namespace in Imports field not imported from: 'gsDesign2'
    All declared Imports should be used.
```

