### PR TITLE
Do not upload coverage results to Codecov when run in a fork

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, master]
   pull_request:
+  workflow_dispatch:
 
 name: test-coverage.yaml
 
@@ -38,6 +39,7 @@ jobs:
         shell: Rscript {0}
 
       - uses: codecov/codecov-action@v4
+        if: github.event.repository.fork == false
         with:
           # Fail if error if not on PR, or if on PR and token is given
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The coverage workflow always fails when I sync my fork because the upload to Codecov fails. Thus I want to disable the upload step unless running on the main repository.

I think I found a good workaround: `if: github.event.repository.fork == false`. It skipped the upload step when I did a [test run](https://github.com/jdblischak/simtrial/actions/runs/12876137723/job/35898635722) from my fork.

My only remaining doubt is what will happen in a Pull Request from a fork (like this one). If the coverage upload step runs for this PR, that is great, and we should merge this change. However, if the the coverage upload is skipped for this PR, I'll have to revert to the less generic `if: github.repository == 'Merck/simtrial'`

Note that I also added the manual trigger `workflow_dispatch:` to make it easier to run the coverage workflow from a feature branch.