### PR TITLE
Remove NOTE from unstated dependency in vignette

### DIFF
--- a/vignettes/discrepancy-between-simtrial-and-survival.Rmd
+++ b/vignettes/discrepancy-between-simtrial-and-survival.Rmd
@@ -13,7 +13,6 @@ vignette: >
 library(gsDesign)
 library(gsDesign2)
 library(dplyr)
-library(tibble)
 library(gt)
 library(simtrial)
 library(tidyr)


### PR DESCRIPTION
Noticed a new NOTE from `R CMD check`:

```
* checking for unstated dependencies in vignettes ... NOTE
'library' or 'require' call not declared from: ‘tibble’
```

This was caused by the line below in the vignette added in https://github.com/Merck/simtrial/pull/308. It can be safely removed.

https://github.com/Merck/simtrial/blob/289eb5d62912e4392bfc9db28bfd4f41a1047b07/vignettes/discrepancy-between-simtrial-and-survival.Rmd#L16
