### PR TITLE
Upload 3 vignettes copied from branch 291

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -60,6 +60,7 @@ Suggests:
     survMisc,
     survRM2,
     testthat,
+    tibble,
     tidyr
 LinkingTo:
     Rcpp

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -86,11 +86,16 @@ articles:
   contents:
   - workflow
   - routines
-- title: "Simulations with NPH tests"
+- title: "Testing methods"
   contents:
   - modest-wlrt
   - maxcombo
   - rmst
+- title: "Simulate fixed/group sequential designs"
+  contents:
+  - sim_fixed_design_simple
+  - sim_gs_design_simple
+  - sim_fixed_design_custom
   - parallel
   - discrepancy-between-simtrial-and-survival
 - title: "NPH distribution approximations"

--- a/vignettes/sim_fixed_design_custom.Rmd
+++ b/vignettes/sim_fixed_design_custom.Rmd
@@ -12,7 +12,6 @@ vignette: >
 library(gsDesign2)
 library(simtrial)
 library(dplyr)
-library(tibble)
 library(gt)
 library(doFuture)
 

--- a/vignettes/sim_fixed_design_custom.Rmd
+++ b/vignettes/sim_fixed_design_custom.Rmd
@@ -213,9 +213,9 @@ cut_data |> head() |> gt() |> tab_header(paste0("An Overview of TTE data Cut at 
 
 # Step 3: Run tests
 
-The `simtrial` package provides many options for testing methods, including (weighted) logrank tests, RMST test, milestone test, and MaxComboi test, see the [Section "Compute p-values/test statistics" at the pkgdown reference page] (https://merck.github.io/simtrial/reference/index.html#compute-p-values-test-statistics).
+The simtrial package provides many options for testing methods, including (weighted) logrank tests, RMST test, milestone test, and MaxComboi test, see the [Section "Compute p-values/test statistics" at the pkgdown reference page] (https://merck.github.io/simtrial/reference/index.html#compute-p-values-test-statistics).
 
-The following code lists all possible tests available in `simtrial`. Users can select one of the tests listed above or combine the testing results to make comparisons across tests. For demonstration purposes, we will aggregate all tests together.
+The following code lists all possible tests available in simtrial. Users can select one of the tests listed above or combine the testing results to make comparisons across tests. For demonstration purposes, we will aggregate all tests together.
 ```{r}
 # Logrank test
 sim_res_lr <- cut_data |> wlr(weight = fh(rho = 0, gamma = 0))

--- a/vignettes/sim_fixed_design_custom.Rmd
+++ b/vignettes/sim_fixed_design_custom.Rmd
@@ -14,7 +14,7 @@ library(simtrial)
 library(dplyr)
 library(gt)
 library(doFuture)
-
+library(tibble)
 set.seed(2025)
 ```
 The vignette [Simulate Fixed Designs with Ease via sim_fixed_n](https://merck.github.io/simtrial/articles/sim_fixed_design_simple.html) presents fixed design simulations using a single function call, `sim_fixed_n()`. It offers a simple and straightforward process for running simulations quickly.

--- a/vignettes/sim_fixed_design_custom.Rmd
+++ b/vignettes/sim_fixed_design_custom.Rmd
@@ -1,0 +1,406 @@
+---
+title: "Custom Fixed Design Simulations: A Tutorial on Writing Code from the Ground Up"
+author: "Yujie Zhao and Keaven Anderson"
+output: rmarkdown::html_vignette
+bibliography: simtrial.bib
+vignette: >
+  %\VignetteIndexEntry{Custom Fixed Design Simulations: A Tutorial on Writing Code from the Ground Up}
+  %\VignetteEngine{knitr::rmarkdown}
+---
+
+```{r, message=FALSE, warning=FALSE}
+library(gsDesign2)
+library(simtrial)
+library(dplyr)
+library(tibble)
+library(gt)
+library(doFuture)
+
+set.seed(2025)
+```
+The vignette [Simulate Fixed Designs with Ease via sim_fixed_n](https://merck.github.io/simtrial/articles/sim_fixed_design_simple.html) presents fixed design simulations using a single function call, `sim_fixed_n()`. It offers a simple and straightforward process for running simulations quickly.
+
+If users are interested in the following aspects, we recommend simulating from scratch rather than directly using `sim_fixed_n()`:
+
+- Tests beyond the logrank test or Fleming-Harrington weighted logrank tests, such as modestly weighted logrank tests, RMST tests, and milestone tests.
+- More complex cutoffs, such as analyzing data after 12 months of follow-up when at least 80% of the patient population is enrolled.
+- Different dropout rates in the control and experimental groups.
+
+The process for simulating from scratch is outlined in Steps 1 to 5 below.
+
+# Step 1: Simulate time-to-event data
+
+The `sim_pw_surv()` function allows for the simulation of a clinical trial with essentially arbitrary patterns of enrollment, failure rates, and censoring. To implement `sim_pw_surv()`, you need to specify 5 design characteristics to simulate time-to-event data:
+
+1. Sample Size (input as `n`).
+1. Stratified or Non-Stratified Designs (input as `stratum`).
+1. Randomization Ratio (input as `block`). The `sim_pw_surv()` function uses fixed block randomization.
+1. Enrollment Rate (input as `enroll_rate`). The `sim_pw_surv()` function supports piecewise enrollment, allowing the enrollment rate to be piecewise constant.
+1. Failure Rate (input as `fail_rate`) or time-to-event rate. The `sim_pw_surv()` function uses a piecewise exponential distribution for the failure rate, which makes it easy to define a distribution with changing failure rates over time. Specifically, in the $j$-th interval, the rate is denoted as $\lambda_j \geq 0$. We require that at least one interval has $\lambda_j > 0$. There are two methods for defining the failure rate:
+  + Specify the failure rate by treatment group, stratum, and time period. An example can be found in Scenario b).
+  + Create a `fail_rate` using `gsDesign2::define_fail_rate`, and then convert it to the required format using `to_sim_pw_surv()`. An example is provided in Scenario a).
+1. Dropout Rate (input as `dropout_Rate`). The `sim_pw_surv()` function accepts piecewise constant dropout rates, which may vary by treatment group. The configuration for dropout should be specified by treatment group, stratum, and time period, and setting up the dropout rate follows the same approach as the failure rate.
+
+
+## Scenario a) The simplest scenario
+
+We begin with the simplest implementation of `sim_pw_surv()`. The following lines of code will generate 500 subjects using equal randomization and an unstratified design.
+
+```{r}
+n_sim <- 100
+n <- 500
+stratum <- data.frame(stratum = "All", p = 1)
+block <- rep(c("experimental", "control"), 2)
+
+enroll_rate <- define_enroll_rate(rate = 12, duration = n / 12)
+
+fail_rate <- define_fail_rate(duration = c(6, Inf), fail_rate = log(2) / 10, 
+                              hr = c(1, 0.7), dropout_rate = 0.0001)
+
+uncut_data_a <- sim_pw_surv(n = n, stratum = stratum, block = block,
+                            enroll_rate = enroll_rate,
+                            fail_rate = to_sim_pw_surv(fail_rate)$fail_rate,
+                            dropout_rate = to_sim_pw_surv(fail_rate)$dropout_rate)
+```
+
+The output of `sim_pw_surv()` is subject-level observations, including stratum, enrollment time for the observation, treatment group the observation is randomized to, failure time, dropout time, calendar time of enrollment plot the minimum of failure time and dropout time (  `cte`), and an failure and dropout indicator (`fail = 1` is a failure, `fail = 0` is a dropout).
+```{r}
+uncut_data_a |> head() |> gt() |> tab_header("An Overview of Simulated TTE data")
+```
+
+## Scenario b) Differential dropout rates
+
+The dropout rate can differ between groups. For instance, in open-label studies, the control group may experience a higher dropout rate. The follow lines of code assumes the control group has a dropout rate of 0.002 for the first 10 months, which then decreases to 0.001 thereafter. In contrast, the experimental group has a constant dropout rate of 0.001 throughout the study. 
+
+```{r}
+differential_dropout_rate <- data.frame(
+  stratum = rep("All", 3), 
+  period = c(1, 2, 1), 
+  treatment = c("control", "control", "experimental"), 
+  duration = c(10, Inf, Inf), 
+  rate = c(0.002, 0.001, 0.001))
+
+uncut_data_b <- sim_pw_surv(n = n, stratum = stratum, block = block,
+                            enroll_rate = enroll_rate,
+                            fail_rate = to_sim_pw_surv(fail_rate)$fail_rate,
+                            dropout_rate = differential_dropout_rate)
+```
+
+## Scenario c) Stratified designs
+
+The following code assumes there are two strata (biomarker-positive and biomarker-negative) with equal prevalence of 0.5 for each. In the control arm, the median survival time is 10 months for biomarker-positive subjects and 8 months for biomarker-negative subjects. For both strata, the hazard ratio is 1 for the first 3 months, after which it decreases to 0.6 for biomarker-positive subjects and 0.8 for biomarker-negative subjects. The dropout rate is contently 0.001 for both strata over time.
+
+```{r}
+stratified_enroll_rate <- data.frame(
+  stratum = c("Biomarker positive", "Biomarker negative"),
+  rate = c(12, 12), 
+  duration = c(1, 1))
+
+stratified_fail_rate <- data.frame(
+  stratum = c(rep("Biomarker positive", 3), rep("Biomarker negative", 3)), 
+  period = c(1, 1, 2, 1, 1, 2), 
+  treatment = rep(c("control", "experimental", "experimental"), 2),
+  duration = c(Inf, 3, Inf, Inf, 3, Inf), 
+  rate = c(# failure rate of biomarker positive subjects: control arm, exp arm period 1, exp arm period 2
+           log(2) / 10, log(2) /10, log(2) / 10 * 0.6,
+           # failure rate of biomarker negative subjects: control arm, exp arm period 1, exp arm period 2
+           log(2) / 8, log(2) /8, log(2) / 8 * 0.8)
+  )
+
+stratified_dropout_rate <- data.frame(
+  stratum = rep(c("Biomarker positive", "Biomarker negative"), each = 2),
+  period = c(1, 1, 1, 1), 
+  treatment = c("control", "experimental", "control", "experimental"),
+  duration = rep(Inf, 4), 
+  rate = rep(0.001, 4)
+  )
+
+uncut_data_c <- sim_pw_surv(n = n,
+                            stratum = data.frame(stratum = c("Biomarker positive", "Biomarker negative"), 
+                                                 p = c(0.5, 0.5)),
+                            block = block,
+                            enroll_rate = stratified_enroll_rate,
+                            fail_rate = stratified_fail_rate,
+                            dropout_rate = stratified_dropout_rate
+                            )
+```
+
+
+For illustration purposes, we will focus on scenario b) for the following discussion.
+
+```{r}
+uncut_data <- uncut_data_b
+```
+
+## Scenario d) Multi-arm designs
+
+Suppose you wish to have 3 arms: control, low-dose and high-dose. The following code assumes the control arm has a median survival time of 10 months, the low-dose arm has a median survival time of 12 months, and the high-dose arm has a median survival time of 14 months. The hazard ratio for the low-dose arm is 0.8, and the hazard ratio for the high-dose arm is 0.6. The dropout rate is 0.001 for all arms.
+Block size is 7 with 3:2:2 randomization.
+
+We begin by setting up enrollment, failure and dropout rates.
+
+```{r}
+enroll_rate <- define_enroll_rate(rate = 12, duration = n / 12)
+multiarm_fail_rate <- data.frame(
+  stratum = c(rep("Control", 2), rep("Low-dose", 2), rep("High-dose", 2)),
+  period = rep(c(1, 2), 3), 
+  treatment = rep(c("control", "experimental", "experimental"), 2),
+  duration = c(Inf, 3, Inf, Inf, 3, Inf), 
+  rate = c(# failure rate of biomarker positive subjects: control arm, exp arm period 1, exp arm period 2
+           log(2) / 10, log(2) /10, log(2) / 10 * 0.6,
+           # failure rate of biomarker negative subjects: control arm, exp arm period 1, exp arm period 2
+           log(2) / 8, log(2) /8, log(2) / 8 * 0.8)
+  )
+
+stratified_dropout_rate <- data.frame(
+  stratum = rep(c("Biomarker positive", "Biomarker negative"), each = 2),
+  period = c(1, 1, 1, 1), 
+  treatment = c("control", "experimental", "control", "experimental"),
+  duration = rep(Inf, 4), 
+  rate = rep(0.001, 4)
+  )
+```
+
+
+```{r}
+three_arm_fail_rate <- data.frame(
+  stratum = "All",
+  period = rep(c(1, 2), 3), 
+  treatment = c("Control", "Control", "Low-dose", "Low-dose", "High-dose", "High-dose"),
+  duration = c(Inf, 3, Inf, Inf, 3, Inf), 
+  rate = c(# failure rate of control arm: period 1, period 2
+           log(2) / c(10, 10),
+           # failure rate of low-dose arm: period 1, period 2
+           log(2) / c(10, 10 / .8),
+           # failure rate of high-dose arm: period 1, period 2
+           log(2) / c(10, 10 / .6)
+           )
+  )
+three_arm_dropout_rate <- data.frame(
+  stratum = rep(c("Control", "Low-dose", "High-dose")),
+  period = c(1, 1, 1), 
+  treatment = c("Control", "Low-dose", "High-dose"),
+  duration = rep(Inf, 3), 
+  rate = rep(0.001, 3)
+  )
+uncut_data_d <- sim_pw_surv(n = n,
+                            stratum = data.frame(stratum = "All"),
+                            block = c(rep("Control", 3), rep("Low-dose", 2), rep("High-dose", 2)),
+                            enroll_rate = enroll_rate,
+                            fail_rate = three_arm_fail_rate,
+                            dropout_rate = three_arm_dropout_rate
+                            )
+```
+
+# Step 2: Cut data
+
+The `get_analysis_date()` derives analysis date for interim/final analysis given multiple conditions, see [the help page of `get_analysis_date()` at the pkgdown website](https://merck.github.io/simtrial/reference/get_analysis_date.html). 
+
+Users can cut for analysis at the 24th month and there are 300 events, whichever arrives later. This is equivalent to `timing_type = 4` in `sim_fixed_n()`.
+```{r}
+cut_date_a <- get_analysis_date(data = uncut_data,
+                                planned_calendar_time = 24,
+                                target_event_overall = 300)
+```
+
+Users can also cut by the maximum of targeted 300 event and minimum follow-up 12 months. This is equivalent to `timing_type = 5` in `sim_fixed_n()`.
+```{r}
+cut_date_b <- get_analysis_date(data = uncut_data,
+                                min_followup = 12,
+                                target_event_overall = 300)
+```
+
+Users can cut data when there are 300 events, with maximum time extension to reach targeted events of 24 months. This is not enabled in `timing_type` of `sim_fixed_n()`.
+
+```{r}
+cut_date_c <- get_analysis_date(data = uncut_data,
+                                max_extension_for_target_event = 12,
+                                target_event_overall = 300)
+```
+
+Users can cut data after 12 months followup when 80\% of the patients are enrolled in the overall population as below. This is not enabled in `timing_type` of `sim_fixed_n()`.
+
+```{r}
+cut_date_d <- get_analysis_date(data = uncut_data,
+                                min_n_overall = 100 * 0.8,
+                                min_followup = 12)
+```
+
+More examples are available in the [reference page of `get_analysis_date()`](https://merck.github.io/simtrial/reference/get_analysis_date.html) For illustration purposes, we will focus on scenario d) for the following discussion.
+
+```{r}
+cut_date <- cut_date_d
+cat("The cutoff date is ", round(cut_date, 2))
+
+cut_data <- uncut_data |> cut_data_by_date(cut_date)
+cut_data |> head() |> gt() |> tab_header(paste0("An Overview of TTE data Cut at ", round(cut_date, 2), "Months"))
+```
+
+# Step 3: Run tests
+
+The `simtrial` package provides many options for testing methods, including (weighted) logrank tests, RMST test, milestone test, and MaxComboi test, see the [Section "Compute p-values/test statistics" at the pkgdown reference page] (https://merck.github.io/simtrial/reference/index.html#compute-p-values-test-statistics).
+
+The following code lists all possible tests available in `simtrial`. Users can select one of the tests listed above or combine the testing results to make comparisons across tests. For demonstration purposes, we will aggregate all tests together.
+```{r}
+# Logrank test
+sim_res_lr <- cut_data |> wlr(weight = fh(rho = 0, gamma = 0))
+
+# weighted logrank test by Fleming-Harrington weights
+sim_res_fh <- cut_data |> wlr(weight = fh(rho = 0, gamma = 0.5))
+
+# Modestly weighted logrank test
+sim_res_mb <- cut_data |> wlr(weight = mb(delay = Inf, w_max = 2))
+
+# Weighted logrank test by Xu 2017's early zero weights
+sim_res_xu <- cut_data |> wlr(weight = early_zero(early_period = 3))
+
+# RMST test
+sim_res_rmst <- cut_data |> rmst(tau = 10)
+
+# Milestone test
+sim_res_ms <- cut_data |> milestone(ms_time = 10)
+
+# Maxcombo tests comboing multiple weighted logrank test with Fleming-Harrington weights
+sim_res_mc <- cut_data |> maxcombo(rho = c(0, 0), gamma = c(0, 0.5))
+```
+
+The output of the tests mentioned above are lists including:
+
+- The testing method employed (WLR, RMST, milestone, or MaxCombo), which can be accessed using `sim_res_rmst$method`.
+- The parameters associated with the testing method. For instance, the RMST test parameter is 10, indicating that the RMST is evaluated at month 10. You can find this information using `sim_res_rmst$parameter`.
+- The point estimate and standard error for the testing method used. For example, the point estimate for RMST represents the survival difference between the experimental group and the control group. This estimate can be retrieved with `sim_res_rmst$estimate` and `sim_res_rmst$se`.
+- The Z-score for the testing method, accessible via `sim_res_rmst$z`. Please note that the Z-score is not provided for the MaxCombo test; instead, the p-value is reported (`sim_res_mc$p_value`).
+
+```{r}
+sim_res <- tribble(
+  ~Method, ~Parameter, ~Z, ~Estimate, ~SE, ~`P value`,
+  sim_res_lr$method, sim_res_lr$parameter, sim_res_lr$z, sim_res_lr$estimate, sim_res_lr$se, pnorm(-sim_res_lr$z),
+  sim_res_fh$method, sim_res_fh$parameter, sim_res_fh$z, sim_res_fh$estimate, sim_res_fh$se, pnorm(-sim_res_fh$z),
+  sim_res_mb$method, sim_res_mb$parameter, sim_res_mb$z, sim_res_mb$estimate, sim_res_mb$se, pnorm(-sim_res_mb$z),
+  sim_res_xu$method, sim_res_xu$parameter, sim_res_xu$z, sim_res_xu$estimate, sim_res_xu$se, pnorm(-sim_res_xu$z),
+  sim_res_rmst$method, sim_res_rmst$parameter|> as.character(), sim_res_rmst$z, sim_res_rmst$estimate, sim_res_rmst$se, pnorm(-sim_res_rmst$z),
+  sim_res_ms$method, sim_res_ms$parameter |> as.character(), sim_res_ms$z, sim_res_ms$estimate, sim_res_ms$se, pnorm(-sim_res_ms$z),
+  sim_res_mc$method, sim_res_mc$parameter, NA, NA, NA, sim_res_mc$p_value
+  ) 
+
+sim_res |> gt() |> tab_header("One Simulation Results")
+```
+
+
+# Step 4: Perform the above single simulation repeatedly
+
+We will now merge Steps 1 to 3 into a single function named `one_sim()`, which facilitates a single simulation run. The construction of `one_sim()` involves copying all the lines of code from Steps 1 to 3.
+
+```{r}
+one_sim <- function(sim_id = 1, 
+                    # arguments from Step 1: design characteristic
+                    n, stratum, enroll_rate, fail_rate, dropout_rate, block, 
+                    # arguments from Step 2； cutting method
+                    min_n_overall, min_followup,
+                    # arguments from Step 3； testing method
+                    fh, mb, xu, rmst, ms, mc
+                    ) {
+    # Step 1: simulate a time-to-event data
+    uncut_data <- sim_pw_surv(
+      n = n,
+      stratum = stratum,
+      block = block,
+      enroll_rate = enroll_rate,
+      fail_rate = fail_rate,
+      dropout_rate = dropout_rate) 
+    
+    ## Step 2: Cut data
+    cut_date <- get_analysis_date(min_n_overall = min_n_overall, min_followup = min_followup, data = uncut_data)
+    cut_data <- uncut_data |> cut_data_by_date(cut_date)
+    
+    # Step 3: Run tests
+    sim_res_lr <- cut_data |> wlr(weight = fh(rho = 0, gamma = 0))
+    sim_res_fh <- cut_data |> wlr(weight = fh(rho = fh$rho, gamma = fh$gamma))
+    sim_res_mb <- cut_data |> wlr(weight = mb(delay = mb$delay, w_max = mb$w_max))
+    sim_res_xu <- cut_data |> wlr(weight = early_zero(early_period = xu$early_period))
+    sim_res_rmst <- cut_data |> rmst(tau = rmst$tau)
+    sim_res_ms <- cut_data |> milestone(ms_time = ms$ms_time)
+    sim_res_mc <- cut_data |> maxcombo(rho = mc$rho, gamma = mc$gamma)
+    
+    sim_res <- tribble(
+      ~`Sim ID`, ~Method, ~Parameter, ~Z, ~Estimate, ~SE, ~`P value`,
+      sim_id, sim_res_lr$method, sim_res_lr$parameter, sim_res_lr$z, sim_res_lr$estimate, sim_res_lr$se, pnorm(-sim_res_lr$z),
+      sim_id, sim_res_fh$method, sim_res_fh$parameter, sim_res_fh$z, sim_res_fh$estimate, sim_res_fh$se, pnorm(-sim_res_fh$z),
+      sim_id, sim_res_mb$method, sim_res_mb$parameter, sim_res_mb$z, sim_res_mb$estimate, sim_res_mb$se, pnorm(-sim_res_mb$z),
+      sim_id, sim_res_xu$method, sim_res_xu$parameter, sim_res_xu$z, sim_res_xu$estimate, sim_res_xu$se, pnorm(-sim_res_xu$z),
+      sim_id, sim_res_rmst$method, sim_res_rmst$parameter|> as.character(), sim_res_rmst$z, sim_res_rmst$estimate, sim_res_rmst$se, pnorm(-sim_res_rmst$z),
+      sim_id, sim_res_ms$method, sim_res_ms$parameter |> as.character(), sim_res_ms$z, sim_res_ms$estimate, sim_res_ms$se, pnorm(-sim_res_ms$z),
+      sim_id, sim_res_mc$method, sim_res_mc$parameter, NA, NA, NA, sim_res_mc$p_value
+  ) 
+      
+    return(sim_res)
+}
+```
+
+After that, we will execute `one_sim()` multiple times using parallel computation. The following lines of code takes 2 works to run 100 simulations. 
+```{r}
+set.seed(2025)
+
+plan("multisession", workers = 2)
+ans <- foreach(
+  sim_id = seq_len(n_sim),
+  .combine = "rbind",
+  .errorhandling = "stop",
+  .options.future = list(seed = TRUE)
+  ) %dofuture% {
+    ans_new <- one_sim(
+      sim_id = sim_id, 
+      # arguments from Step 1: design characteristic
+      n = n, 
+      stratum = stratum, 
+      enroll_rate = enroll_rate, 
+      fail_rate = to_sim_pw_surv(fail_rate)$fail_rate, 
+      dropout_rate = differential_dropout_rate, 
+      block = block, 
+      # arguments from Step 2； cutting method
+      min_n_overall = 500 * 0.8,
+      min_followup = 12,
+      # arguments from Step 3； testing method
+      fh = list(rho = 0, gamma = 0.5), 
+      mb = list(delay = Inf, w_max = 2), 
+      xu = list(early_period = 3), 
+      rmst = list(tau = 10), 
+      ms = list(ms_time = 10), 
+      mc = list(rho = c(0, 0), gamma = c(0, 0.5))
+      )
+                              
+    ans_new
+  }
+
+plan("sequential")
+```
+
+The output from the parallel computation resembles the output of `sim_fix_n()` described in the vignette [Simulate Fixed Designs with Ease via sim_fixed_n](https://merck.github.io/simtrial/articles/sim_fixed_design_simple.html). Each row in the output corresponds to the simulation results for each testing method per each repeation. 
+
+```{r}
+ans |> head() |> gt() |> tab_header("Overview Each Simulation results")
+```
+
+# Step 5: Summarize simulations
+
+Using the 100 parallel simulations provided above, users can summarize the simulated power and compare it across different testing methods with some data manipulation using `dplyr`. Please note that the power calculation for the MaxCombo test differs from the other tests, as it does not report a Z-score.
+
+```{r, message=FALSE}
+ans_non_mc <- ans |>
+  filter(Method != "MaxCombo") |>
+  group_by(Method, Parameter) %>% 
+  summarise(Power = mean(Z > -qnorm(0.025))) |>
+  ungroup()
+
+ans_mc <- ans |>
+  filter(Method == "MaxCombo") |>
+  summarize(Power = mean(`P value` < 0.025), Method = "MaxCombo", Parameter = "FH(0, 0) + FH(0, 0.5)") 
+
+ans_non_mc |>
+  union(ans_mc) |>
+  gt() |>
+  tab_header("Summary from 100 simulations")
+```
+
+
+## References

--- a/vignettes/sim_fixed_design_custom.Rmd
+++ b/vignettes/sim_fixed_design_custom.Rmd
@@ -125,13 +125,6 @@ uncut_data_c <- sim_pw_surv(n = n,
                             )
 ```
 
-
-For illustration purposes, we will focus on scenario b) for the following discussion.
-
-```{r}
-uncut_data <- uncut_data_b
-```
-
 ## Scenario d) Multi-arm designs
 
 Suppose you wish to have 3 arms: control, low-dose and high-dose. The following code assumes the control arm has a median survival time of 10 months, the low-dose arm has a median survival time of 12 months, and the high-dose arm has a median survival time of 14 months. The hazard ratio for the low-dose arm is 0.8, and the hazard ratio for the high-dose arm is 0.6. The dropout rate is 0.001 for all arms.
@@ -141,55 +134,38 @@ We begin by setting up enrollment, failure and dropout rates.
 
 ```{r}
 enroll_rate <- define_enroll_rate(rate = 12, duration = n / 12)
-multiarm_fail_rate <- data.frame(
-  stratum = c(rep("Control", 2), rep("Low-dose", 2), rep("High-dose", 2)),
-  period = rep(c(1, 2), 3), 
-  treatment = rep(c("control", "experimental", "experimental"), 2),
-  duration = c(Inf, 3, Inf, Inf, 3, Inf), 
-  rate = c(# failure rate of biomarker positive subjects: control arm, exp arm period 1, exp arm period 2
-           log(2) / 10, log(2) /10, log(2) / 10 * 0.6,
-           # failure rate of biomarker negative subjects: control arm, exp arm period 1, exp arm period 2
-           log(2) / 8, log(2) /8, log(2) / 8 * 0.8)
-  )
 
-stratified_dropout_rate <- data.frame(
-  stratum = rep(c("Biomarker positive", "Biomarker negative"), each = 2),
-  period = c(1, 1, 1, 1), 
-  treatment = c("control", "experimental", "control", "experimental"),
-  duration = rep(Inf, 4), 
-  rate = rep(0.001, 4)
-  )
-```
-
-
-```{r}
 three_arm_fail_rate <- data.frame(
   stratum = "All",
-  period = rep(c(1, 2), 3), 
-  treatment = c("Control", "Control", "Low-dose", "Low-dose", "High-dose", "High-dose"),
-  duration = c(Inf, 3, Inf, Inf, 3, Inf), 
+  period = c(1, 1, 2, 1, 2), 
+  treatment = c("control", "low-dose", "low-dose", "high-dose", "high-dose"),
+  duration = c(Inf, 3, Inf, 3, Inf), 
   rate = c(# failure rate of control arm: period 1, period 2
-           log(2) / c(10, 10),
+           log(2) / 10,
            # failure rate of low-dose arm: period 1, period 2
            log(2) / c(10, 10 / .8),
            # failure rate of high-dose arm: period 1, period 2
-           log(2) / c(10, 10 / .6)
-           )
-  )
+           log(2) / c(10, 10 / .6)))
+
 three_arm_dropout_rate <- data.frame(
-  stratum = rep(c("Control", "Low-dose", "High-dose")),
+  stratum = rep(c("control", "low-dose", "high-dose")),
   period = c(1, 1, 1), 
-  treatment = c("Control", "Low-dose", "High-dose"),
+  treatment = c("control", "low-dose", "high-dose"),
   duration = rep(Inf, 3), 
-  rate = rep(0.001, 3)
-  )
+  rate = rep(0.001, 3))
+
 uncut_data_d <- sim_pw_surv(n = n,
                             stratum = data.frame(stratum = "All"),
-                            block = c(rep("Control", 3), rep("Low-dose", 2), rep("High-dose", 2)),
+                            block = c(rep("control", 3), rep("low-dose", 2), rep("high-dose", 2)),
                             enroll_rate = enroll_rate,
                             fail_rate = three_arm_fail_rate,
-                            dropout_rate = three_arm_dropout_rate
-                            )
+                            dropout_rate = three_arm_dropout_rate)
+```
+
+For illustration purposes, we will focus on scenario b) for the following discussion.
+
+```{r}
+uncut_data <- uncut_data_b
 ```
 
 # Step 2: Cut data

--- a/vignettes/sim_fixed_design_custom.Rmd
+++ b/vignettes/sim_fixed_design_custom.Rmd
@@ -147,7 +147,7 @@ three_arm_fail_rate <- data.frame(
            log(2) / c(10, 10 / .6)))
 
 three_arm_dropout_rate <- data.frame(
-  stratum = rep(c("control", "low-dose", "high-dose")),
+  stratum = "All",
   period = c(1, 1, 1), 
   treatment = c("control", "low-dose", "high-dose"),
   duration = rep(Inf, 3), 

--- a/vignettes/sim_fixed_design_simple.Rmd
+++ b/vignettes/sim_fixed_design_simple.Rmd
@@ -1,0 +1,167 @@
+---
+title: "Simulate Fixed Designs with Ease via sim_fixed_n"
+author: "Yujie Zhao and Keaven Anderson"
+output: rmarkdown::html_vignette
+bibliography: simtrial.bib
+vignette: >
+  %\VignetteIndexEntry{Simulate Fixed Designs with Ease via sim_fixed_n}
+  %\VignetteEngine{knitr::rmarkdown}
+---
+
+```{r, message=FALSE, warning=FALSE}
+library(gsDesign2)
+library(simtrial)
+library(dplyr)
+library(gt)
+
+set.seed(2027)
+```
+
+The `sim_fixed_n()` function simulates a two-arm trial with a single endpoint, accounting for time-varying enrollment, hazard ratios, and failure and dropout rates. 
+
+While there are limitations, there are advantages of calling `sim_fixed_n()` directly:
+
+- It is simple, which allows for a single function call to perform an arbitrary number of simulations.
+- It automatically implements a parallel computating backend to reduce running time.
+- It offers up to 5 options for determining the data cutoff for analysis through the `timing_type` parameter.
+
+If people are interested in more complicated simulations, please refer to the vignette [Custom Fixed Design Simulations: A Tutorial on Writing Code from the Ground Up](https://merck.github.io/simtrial/articles/sim_fixed_design_custom.html).
+
+The process for simulating via `sim_fixed_n()` is outlined in Steps 1 to 3 below.
+
+# Step 1: Define design parameters
+
+To run simulations for a fixed design, several design characteristics may be used. 
+Depending on the data cutoff for analysis option, different inputs may be required.
+The following lines of code specify an unstratified 2-arm trial with equal randomization. 
+The simulation is repeated 2 times. 
+Enrollment is targeted to last for 12 months at a constant enrollment rate. 
+The median for the control arm is 10 months, with a delayed effect during the first 3 months followed by a hazard ratio of 0.7 thereafter. 
+There is an exponential dropout rate of 0.001 over time.
+
+```{r}
+n_sim <- 100
+total_duration <- 36
+stratum <- data.frame(stratum = "All", p = 1)
+block <- rep(c("experimental", "control"), 2)
+
+enroll_rate <- data.frame(stratum = "All", rate = 12, duration = 500 / 12)
+fail_rate <- data.frame(stratum = "All",
+                        duration = c(3, Inf), fail_rate = log(2) / 10, 
+                        hr = c(1, 0.6), dropout_rate = 0.001)
+```
+
+We specify sample size and targeted event count based on the `fixed_design_ahr()` function and the above options.
+The following design computes the sample size and targeted event counts for 85\% power. 
+In this approach, users can obtain the sample size and targeted events from the output of `x`, specifically by using `sample_size <- x$analysis$n` and `target_event <- x$analysis$event`.
+
+```{r}
+x <- fixed_design_ahr(enroll_rate = enroll_rate, fail_rate = fail_rate, 
+                      alpha = 0.025, power = 0.85, ratio = 1, 
+                      study_duration = total_duration) |> to_integer()
+x |> summary() |> gt() |> 
+  tab_header(title = "Sample Size and Targeted Events Based on AHR Method", 
+             subtitle = "Fixed Design with 85% Power, One-sided 2.5% Type I error") |>
+  fmt_number(columns = c(4, 5, 7), decimals = 2)
+```
+
+Now we set the derived targeted sample size, enrollment rate, and event count from the above.
+
+```{r}
+sample_size <- x$analysis$n
+target_event <- x$analysis$event
+enroll_rate <- x$enroll_rate
+```
+
+
+# Step 2: Run `sim_fixed_n()`
+
+Now that we have set up the design characteristics in Step 1, we can proceed to run `sim_fix_n()` for our simulations. This function automatically utilizes a parallel computing backend, which helps reduce the running time.
+
+The `timing_type` specifies one or more of the following cutoffs for setting the time for analysis:
+
+  + `timing_type = 1`: The planned study duration.
+  + `timing_type = 2`: The time until target event count has been observed.
+  + `timing_type = 3`: The planned minimum follow-up period after enrollment completion.
+  + `timing_type = 4`: The maximum of planned study duration and time to observe the targeted event count (i.e., using `timing_type = 1` and `timing_type = 2` together).
+  + `timing_type = 5`: The maximum of time to observe the targeted event count and minimum follow-up following enrollment completion  (i.e., using `timing_type = 2` and `timing_type = 3` together).
+
+The `rho_gamma` argument is a data frame containing the variables `rho` and `gamma`, both of which should be greater than or equal to zero, to specify one Fleming-Harrington weighted log-rank test per row. 
+For instance, setting `rho = 0` and `gamma = 0` yields the standard unweighted log-rank test, while `rho = 0 and gamma = 0.5` provides the weighted Fleming-Harrington (0, 0.5) log-rank test. 
+If you are interested in tests other than the Fleming-Harrington weighted log-rank test, please refer to the vignette [Custom Fixed Design Simulations: A Tutorial on Writing Code from the Ground Up](https://merck.github.io/simtrial/articles/sim_fixed_design_custom.html).
+
+```{r, message=FALSE}
+sim_res <- sim_fixed_n(
+  n_sim = 2, # only use 2 simulations for initial run
+  sample_size = sample_size, 
+  block = block, 
+  stratum = stratum,
+  target_event = target_event, 
+  total_duration = total_duration,
+  enroll_rate = enroll_rate, 
+  fail_rate = fail_rate,
+  timing_type = 1:5, 
+  rho_gamma = data.frame(rho = 0, gamma = 0))
+```
+
+The output of `sim_fixed_n` is a data frame with one row per simulated dataset per cutoff specified in `timing_type`, per test statistic specified in `rho_gamma`.
+Here we have just run 2 simulated trials and see how the different cutoffs vary for the 2 trial instances.
+
+```{r}
+sim_res |>
+  gt() |>
+  tab_header("Tests for Each Simulation Result", subtitle = "Logrank Test for Different Analysis Cutoffs") |>
+  fmt_number(columns = c(4, 5, 7), decimals = 2)
+```
+
+# Step 3: Summarize simulations
+
+Now we run `r n_sim` simulated trials and summarize the results by how data is cutoff for analysis.
+
+```{r, message=FALSE}
+sim_res <- sim_fixed_n(
+  n_sim = n_sim,
+  sample_size = sample_size, 
+  block = block, stratum = stratum,
+  target_event = target_event, 
+  total_duration = total_duration,
+  enroll_rate = enroll_rate, 
+  fail_rate = fail_rate,
+  timing_type = 1:5, 
+  rho_gamma = data.frame(rho = 0, gamma = 0))
+```
+
+With the `r n_sim` simulations provided, users can summarize the simulated power and compare it to the targeted 85\% power.
+All cutoff methods approximate the targeted power well and have a similar average duration and mean number of events.
+
+```{r}
+sim_res |>
+  group_by(cut) |>
+  summarize(`Simulated Power` = mean(z > qnorm(1 - 0.025)), 
+            `Mean events` = mean(event),
+            `Mean duration` = mean(duration)) |>
+  mutate(`Sample size` = sample_size,
+         `Targeted events` = target_event) |>
+  gt() |>
+  tab_header(title = "Summary of 100 simulations by 5 different analysis cutoff methods",
+             subtitle = "Tested by logrank") |>
+  fmt_number(columns = c(2:4), decimals = 2)
+```
+
+We can also do things like summarize distribution of event counts at the planned study duration.
+We can see the event count varies a fair amount.
+
+```{r, fig.width = 6}
+hist(sim_res$event[sim_res$cut == "Planned duration"], 
+     breaks = 10,
+     main = "Distribution of Event Counts at Planned Study Duration",
+     xlab = "Event Count at Targeted Trial Duration")
+```
+
+We also evaluate the distribution of the trial duration when analysis is performed when the targeted events are achieved.
+
+```{r, fig.width = 6}
+plot(density(sim_res$duration[sim_res$cut == "Targeted events"]), 
+     main = "Trial Duration Smoothed Density",
+     xlab = "Trial duration when Targeted Event Count is Observed")
+```

--- a/vignettes/sim_gs_design_simple.Rmd
+++ b/vignettes/sim_gs_design_simple.Rmd
@@ -1,0 +1,191 @@
+---
+title: "Simulate Group Sequential Designs with Ease via sim_gs_n"
+author: "Yujie Zhao and Keaven Anderson"
+output: rmarkdown::html_vignette
+bibliography: simtrial.bib
+vignette: >
+  %\VignetteIndexEntry{Simulate Group Sequential Designs with Ease via sim_gs_n}
+  %\VignetteEngine{knitr::rmarkdown}
+---
+
+```{r, message=FALSE, warning=FALSE}
+library(gsDesign2)
+library(simtrial)
+library(dplyr)
+library(gt)
+
+set.seed(2025)
+```
+
+The `sim_gs_n()` function simulates group sequential designs with fixed sample size and multiple analyses. There are many advantages of calling `sim_gs_n()` directly.
+
+- It is simple, which allows for a single function call to perform thousands of simulations.
+- It allows for a variety of testing methods, such as logrank, weighted logrank test, RMST, and milestone test, via the `test = ...` argument.
+- It automatically implements a parallel computation backend, allowing users to achieve shorter running times.
+- It enables flexible data cutting methods for analyses, specifically: (1) planned calendar time, (2) targeted events, (3) maximum time extension to reach targeted events, (4) planned minimum time after the previous analysis, (5) minimal follow-up time after specified enrollment fraction; various combinations of these cut methods can also be specified.
+
+The process for simulating via `sim_gs_n()` is outlined in Steps 1 to 3 below.
+
+For those interested in more complicated simulations should refer to the vignette [Custom Group Sequential Design Simulations: Crafting from Scratch](https://merck.github.io/simtrial/articles/sim_gs_design_custom.html).
+
+# Step 1: Define design paramaters
+
+To run simulations for a group sequential design, several design characteristics are required. 
+The following code creates a design for an unstratified 2-arm trial with equal randomization. 
+Enrollment is targeted to last for 12 months at a constant enrollment rate. 
+The control arm is specified as exponential with a median of 10 months.
+The experimental arm distribution has a piecewise exponential distribution with a delay of 3 months with no benefit relative to control (HR = 1) followed by a hazard ratio of 0.6 thereafter. 
+Additionally, there is an exponential dropout rate of 0.001 per month (or unit of time). 
+The set up of these parameters is similar to the vignette [Simulate Fixed Designs with Ease via sim_fixed_n](https://merck.github.io/simtrial/articles/sim_fixed_design_simple.html).
+The total sample size is derived for 90\% power. 
+
+```{r}
+stratum <- data.frame(stratum = "All", p = 1)
+block <- rep(c("experimental", "control"), 2)
+# enrollment rate will be updated later, 
+# multiplied by a constant to get targeted power
+enroll_rate <- data.frame(stratum = "All", rate = 1, duration = 12)
+fail_rate <- data.frame(stratum = "All",
+                        duration = c(3, Inf), fail_rate = log(2) / 10, 
+                        hr = c(1, 0.6), dropout_rate = 0.001)
+# Derive design using the average hazard ratio method
+x <- gs_design_ahr(enroll_rate = enroll_rate, fail_rate = fail_rate,
+                   analysis_time = c(12, 24, 36), alpha = 0.025, beta = 0.1,
+                   # spending function for upper bound
+                   upper = gs_spending_bound, 
+                   upar = list(sf = gsDesign::sfLDOF, total_spend = 0.025),
+                   # Fixed lower bound
+                   lower = gs_b,
+                   lpar = rep(-Inf, 3)) |> to_integer()
+
+sample_size <- x$analysis$n |> max()
+event <- x$analysis$event
+eff_bound <- x$bound$z[x$bound$bound == "upper"]
+```
+
+```{r}
+cat(paste("The total sample size is ", sample_size, "\n", sep = ''))
+cat("The number of events at IA1, IA2 and FA are:", event, "\n")
+cat("The efficacy bounds at IA1, IA2 and FA are:", round(eff_bound, 3), "\n")
+cat("Targeted analysis times:", round(x$analysis$time, 1), "\n")
+```
+
+Now we get the updated planned enrollment rate from the design to achieve the above targeted sample size.
+
+```{r}
+enroll_rate <- x$enroll_rate
+enroll_rate
+```
+
+
+There are additional parameters required for a group sequential design simulation as demonstrated below. 
+One is the testing method. We focus on logrank here. 
+Users can change these to other tests of interest; in comments below we demonstrate logrank and modestly weighted logrank test (@MagirrBurman) and Fleming-Harrington (@FH1982) tests; how to set up group sequential designs for these alternate tests is beyond the scope of this article.
+More testing methods are available at [reference page of `simtrial`](https://merck.github.io/simtrial/reference/index.html#compute-p-values-test-statistics).
+
+```{r}
+# Example for logrank
+weight <- fh(rho = 0, gamma = 0)
+test <- wlr
+# Example for Modestly Weighted Logrank Test (Magirr-Burman)
+# weight <- mb(delay = Inf, w_max = 2)
+# Example for Fleming-Harrington(0, 0.5)
+# weight <- fh(rho = 0, gamma = 0.5)
+```
+
+The final step is to specify how when data is cut off for each analysis in the group sequential design. 
+The `create_cut()` function includes 5 options for the analysis cutoff: 
+
+(1) planned calendar time, 
+(2) targeted events, 
+(3) maximum time extension to reach targeted events, 
+(4) planned minimum time after the previous analysis, and
+(5) minimal follow-up time after specified enrollment fraction. 
+
+More details and examples are available at the [help page](https://merck.github.io/simtrial/reference/get_analysis_date.html).
+
+A straightforward method for cutting analyses is based on events. For instance, the following code specifies 2 interim analyses and 1 final analysis cut when `r event` events occur. **In this event-driven approach, there is no need to update the efficacy boundary.**
+
+```{r}
+ia1_cut <- create_cut(target_event_overall = event[1])
+ia2_cut <- create_cut(target_event_overall = event[2])
+fa_cut <- create_cut(target_event_overall = event[3])
+
+cut <- list(ia1 = ia1_cut, ia2 = ia2_cut, fa = fa_cut)
+```
+
+Users can set more complex cutting. For example, 
+
+- The first interim analysis occurs at the targeted IA 1 analyusis time or when at least the IA 1 targeted events are observed, which is later. 
+However, if the target number of events is not reached, we will wait a maximum of 16 months from start of enrollment.
+- The second interim analysis is targeted to take place at the targeted time or targeted events for IA 2, whichever is later. Additionally, this interim analysis will be scheduled at least 10 months after the first interim analysis, but no later than 28 months from start of enrollment.
+- The final analysis is set for the targeted final analysis time or targeted events at the final analysis, whichever is later.
+It must be at least 6 months after IA 2. 
+
+**Please keep in mind that if the cut is not event-driven, boundary updates are necessary; this is not covered here.** 
+You can find more information about [the boundary updates in the boundary update vignette](https://merck.github.io/simtrial/articles/sim_fixed_design_simple.html). 
+In this vignette, we use the event-driven cut from above for illustrative purposes.
+
+```{r, eval=FALSE}
+ia1_cut <- create_cut(
+  planned_calendar_time = round(x$analysis$time[1]), 
+  target_event_overall = x$analysis$event[1],
+  max_extension_for_target_event = 16)
+
+ia2_cut <- create_cut(
+  planned_calendar_time = round(x$analysis$time[2]),
+  target_event_overall = x$analysis$event[2],
+  min_time_after_previous_analysis = 10, 
+  max_extension_for_target_event = 28)
+
+fa_cut <- create_cut(
+  planned_calendar_time = round(x$analysis$time[3]),
+  min_time_after_previous_analysis = 6,
+  target_event_overall = x$analysis$event[3])
+
+cut <- list(ia1 = ia1_cut, ia2 = ia2_cut, fa = fa_cut)
+```
+
+# Step 2: Run `sim_gs_n()`
+
+Now that we have set up the design characteristics in Step 1, we can proceed to run `sim_gs_n()` for a specified number of simulations. 
+This function automatically utilizes a parallel computing backend, which helps reduce the running time.
+
+```{r, message=FALSE}
+n_sim <- 100 # Number of simulated trials
+sim_res <- sim_gs_n(
+  n_sim = n_sim,
+  sample_size = sample_size, stratum = stratum, block = block,
+  enroll_rate = enroll_rate, fail_rate = fail_rate,
+  test = test, weight = weight, cut = cut)
+```
+
+The output of `sim_gs_n` is a data frame with one row per simulation per analysis.
+We show results for the first 2 simulated trials here. 
+The estimate column is the *sum(0 - E)* for the logrank test; the se column is its standard error estimated under the null hypothesis.
+The `z` column is the test statistic for the logrank test (estimate / se). 
+The `info` and `info0` columns are the information at the current analysis under the alternate and null hypotheses, respectively.
+
+```{r}
+sim_res |> head(n = 6) |> gt() |> tab_header("Overview Each Simulation results") |>
+  fmt_number(columns = c(5, 8:12), decimals = 2)
+```
+
+# Step 3: Summarize simulations
+
+With the `r n_sim` simulations provided, users can summarize the simulated power and compare it to the target power of 90\% as follows:
+
+```{r, message=FALSE}
+sim_res |>
+  left_join(data.frame(analysis = 1:3, eff_bound = eff_bound)) |>
+  group_by(analysis) |>
+  summarize(`Mean time` = mean(cut_date), `sd(time)` = sd(cut_date), `Simulated power` = mean(z >= eff_bound)) |>
+  ungroup() |>
+  mutate(`Asymptotic power` = x$bound$probability[x$bound$bound == "upper"]) |>
+  gt() |>
+  tab_header("Summary of 100 simulations") |> 
+  fmt_number(columns = 2, decimals = 1) |>
+  fmt_number(columns = 3:5, decimals = 2)
+```
+
+## References


### PR DESCRIPTION
This issue adds 2 vignettes introducing fixed/group sequential design simulations via a single function call.
- [x] Simulate Fixed Designs with Ease via sim_fixed_n
- [x] Simulate Group Sequential Designs with Ease via sim_gs_n


This issue also includes 1 vignette introducing fixed sequential design simulations by writing the code from the ground up.
- [x] Custom Fixed Design Simulations: A Tutorial on Writing Code from the Ground Up