### PR TITLE
Replace `foreach(.combine = "rbind")` with manual combine for optimal speed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# simtrial 0.4.2.9000
+
+## Speed improvements
+
+- Optimize parallel simulation speed in `sim_fixed_n()` and `sim_gs_n()` by
+  replacing `foreach(.combine = "rbind")` with manual data frame combination
+  (@nanxstats, #318).
+
 # simtrial 0.4.2
 
 ## Statistical improvements

--- a/R/sim_fixed_n.R
+++ b/R/sim_fixed_n.R
@@ -252,7 +252,6 @@ sim_fixed_n <- function(
   # parallel computation start ----
   results <- foreach::foreach(
     i = seq_len(n_sim),
-    .combine = "rbind",
     .errorhandling = "stop",
     .options.future = list(seed = TRUE)
   ) %dofuture% {
@@ -372,6 +371,7 @@ sim_fixed_n <- function(
     results_sim[, sim := i]
     results_sim
   }
+  results <- rbindlist(results)
   setDF(results)
   return(results)
 }

--- a/R/sim_gs_n.R
+++ b/R/sim_gs_n.R
@@ -276,7 +276,6 @@ sim_gs_n <- function(
   ans <- foreach::foreach(
     sim_id = seq_len(n_sim),
     test = replicate(n=n_sim, expr=test, simplify = FALSE),
-    .combine = "rbind",
     .errorhandling = "stop",
     .options.future = list(seed = TRUE)
   ) %dofuture% {
@@ -336,6 +335,7 @@ sim_gs_n <- function(
     ans_1sim
   }
 
+  ans <- rbindlist(ans)
   setDF(ans)
 
   test_method <- ans$method[ans$sim_id == 1]

--- a/vignettes/sim_fixed_design_custom.Rmd
+++ b/vignettes/sim_fixed_design_custom.Rmd
@@ -319,7 +319,6 @@ set.seed(2025)
 plan("multisession", workers = 2)
 ans <- foreach(
   sim_id = seq_len(n_sim),
-  .combine = "rbind",
   .errorhandling = "stop",
   .options.future = list(seed = TRUE)
   ) %dofuture% {
@@ -346,6 +345,8 @@ ans <- foreach(
                               
     ans_new
   }
+
+ans <- data.table::rbindlist(ans)
 
 plan("sequential")
 ```


### PR DESCRIPTION
This PR replaces `foreach(.combine = "rbind")` with manual combine using `rbindlist()`.

@keaven and I discovered that `foreach(.combine = "rbind")` is an inefficient implementation that can double the compute time compared to combining later manually when the number of simulations gets moderately large (> 10,000) - half of that time is spent on burning one CPU core to combine the data frames.

See my [blog post](https://nanx.me/blog/post/r-foreach-combine/) for generic benchmarking results.