### PR TITLE
Install {future} 1.34.0 for Windows CI

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,6 +44,13 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
+      - name: Install future 1.34 for Windows
+        if: runner.os == 'Windows'
+        shell: Rscript {0}
+        run: |
+          install.packages("remotes")
+          remotes::install_version("future", "1.34.0")
+
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true


### PR DESCRIPTION
This is a temporary workaround to fix `R CMD check` on Windows until we find a long-term solution.

**Background:**

* Today I discovered that the `R CMD check` workflow was broken in our Windows CI (https://github.com/Merck/simtrial/pull/321#issuecomment-2794890052)
* This was caused by today's release of {future} 1.40.0
* According to its [`NEWS`](https://cran.r-project.org/web/packages/future/news/news.html): "This update is fully backward compatible with previous versions."
* With {future} 1.40.0, the vignette `parallel.Rmd` fails with `could not find function "sim_pw_surv"`
* I cannot reproduce this error on my local Windows machine. This likely explains why it wasn't caught by the CRAN reverse dependency checks
* My first idea was to add an upper bound of `future (< 1.40)` to `DESCRIPTION`, but for some reason `r-lib/actions/setup-r-dependencies@v2` couldn't process the upper bound on macOS or Windows. It ran fine in the Ubuntu builds. I also confirmed `pak::pak()` could handle the upper bound just fine on my local Windows machine.
* So for now just installing {future} 1.34.0 for the Windows CI until we can figure out what is causing the error