### PR TITLE
Add Merck ROR ID to package metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,8 @@ Authors@R: c(
     person("Heng", "Zhou", role = c("ctb")),
     person("Amin", "Shirazi", role = c("ctb")),
     person("Cole", "Manschot", role = c("ctb")),
-    person("Merck & Co., Inc., Rahway, NJ, USA and its affiliates", role = "cph")
+    person("Merck & Co., Inc., Rahway, NJ, USA and its affiliates", role = "cph",
+           comment = c(ROR = "02891sr49"))
     )
 Description: Provides some basic routines for simulating a
     clinical trial. The primary intent is to provide some tools to

--- a/man/simtrial-package.Rd
+++ b/man/simtrial-package.Rd
@@ -42,7 +42,7 @@ Other contributors:
   \item Heng Zhou [contributor]
   \item Amin Shirazi [contributor]
   \item Cole Manschot [contributor]
-  \item Merck & Co., Inc., Rahway, NJ, USA and its affiliates [copyright holder]
+  \item Merck & Co., Inc., Rahway, NJ, USA and its affiliates (02891sr49) [copyright holder]
 }
 
 }


### PR DESCRIPTION
CRAN and {pkgdown} [2.1.2](https://github.com/r-lib/pkgdown/releases/tag/v2.1.2) now support linking to an organization's ROR ID: https://ror.org/02891sr49