### PR TITLE
Relax test tolerance for summary.simtrial_gs_wlr()

### DIFF
--- a/tests/testthat/test-unvalidated-summary.R
+++ b/tests/testthat/test-unvalidated-summary.R
@@ -87,7 +87,7 @@ test_that("summary.simtrial_gs_wlr() returns consistent results for one-sided de
       design_type = "one-sided",
       method = "FH(rho=0, gamma=0.5)"
     )
-  expect_equal(observed, expected)
+  expect_equal(observed, expected, tolerance = 1e-6)
 })
 
 test_that("summary.simtrial_gs_wlr() returns consistent results for two-sided design", {
@@ -179,5 +179,5 @@ test_that("summary.simtrial_gs_wlr() returns consistent results for two-sided de
       class = c("simtrial_gs_wlr", "data.frame"),
       method = "FH(rho=0, gamma=0.5)"
     )
-  expect_equal(observed, expected)
+  expect_equal(observed, expected, tolerance = 1e-6)
 })


### PR DESCRIPTION
Closes #328 

Some minor numerical differences (on the order of `1e-7`) were introduced by https://github.com/Merck/gsDesign2/pull/528. If these can be safely ignored, this PR fixes the tests by relaxing the tolerance to `1e-6`.