### PR TITLE
Install latest {future} to fix Windows CI

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,13 +44,6 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
-      - name: Install future 1.34 for Windows
-        if: runner.os == 'Windows'
-        shell: Rscript {0}
-        run: |
-          install.packages("remotes")
-          remotes::install_version("future", "1.34.0")
-
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true


### PR DESCRIPTION
Closes #327

xref: https://github.com/Merck/simtrial/pull/322, #329 

The bug introduced in {future} 1.40.0 was fixed in 1.49.0
