### PR TITLE
Add test and reduce namespace requirements for `sim_gs_n()` with updated bounds

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,7 @@ Suggests:
     dplyr,
     ggplot2,
     gsDesign,
-    gsDesign2(>= 1.1.3.4),
+    gsDesign2 (>= 1.1.3.4),
     gt,
     knitr,
     rmarkdown,

--- a/R/sim_gs_n.R
+++ b/R/sim_gs_n.R
@@ -375,7 +375,7 @@ sim_gs_n <- function(
         # Get the change point of the piecewise HR, ended by study duration
         fr_chg_pt <- pmin(cumsum(original_design$fail_rate$duration), study_duration)
         pw_event <- sapply(fr_chg_pt,
-                           function(threshold) {simu_data_cut |> dplyr::filter(tte <= threshold, event == 1) |> nrow()})
+                           function(threshold) {simu_data_cut |> subset(tte <= threshold & event == 1) |> nrow()})
         event_tbl_new <- data.frame(analysis = rep(i_analysis, length(pw_event)),
                                     event = diff(c(0, pw_event)))
         event_tbl <- rbind(event_tbl, event_tbl_new)
@@ -391,7 +391,7 @@ sim_gs_n <- function(
       ans_1sim$planed_lower_bound <- planed_lower_bound
 
       # Calculate ustime and lstime
-      obs_event <- (event_tbl |> dplyr::group_by(analysis) |> dplyr::summarize(x = sum(event)))$x
+      obs_event <- with(event_tbl, tapply(event, analysis, sum, simplify = TRUE))
       plan_event <- original_design$analysis$event
       if (ia_alpha_spending == "actual" && fa_alpha_spending == "info_frac"){
         ustime <- obs_event / plan_event[n_analysis]

--- a/tests/testthat/test-unvalidated-sim_gs_n.R
+++ b/tests/testthat/test-unvalidated-sim_gs_n.R
@@ -1,6 +1,8 @@
 # 2024-02-22: Converted `example("sim_gs_n")` to tests from commit 306de0d
 # https://github.com/Merck/simtrial/tree/306de0dbe380fdb1e906a59f34bf3871d3ee5312
 
+skip_if_not_installed("gsDesign2")
+
 # parameters for enrollment
 enroll_rampup_duration <- 4 # duration for enrollment ramp up
 enroll_duration <- 16 # total enrollment duration
@@ -657,4 +659,50 @@ test_that("create_cut() can accept variables as arguments", {
     weight = simtrial::fh(rho = 0, gamma = 0))
 
   expect_equal(results_parallel, results_sequential)
+})
+
+test_that("Updating bounds changes the simulation results", {
+  x <- gsDesign2::gs_design_ahr(analysis_time = 1:3*12) |>
+    gsDesign2::to_integer()
+
+  # No boundary updates
+  set.seed(1)
+  run1 <- sim_gs_n(
+    n_sim = 1,
+    sample_size = max(x$analysis$n),
+    enroll_rate = x$enroll_rate,
+    fail_rate = x$fail_rate,
+    test = wlr,
+    cut = list(ia1 = create_cut(planned_calendar_time = x$analysis$time[1]),
+               ia2 = create_cut(planned_calendar_time = x$analysis$time[2]),
+               fa = create_cut(planned_calendar_time = x$analysis$time[3])),
+    weight = fh(rho = 0, gamma = 0)
+  )
+
+  # With boundary updates
+  set.seed(1)
+  run2 <- sim_gs_n(
+    n_sim = 1,
+    sample_size = max(x$analysis$n),
+    enroll_rate = x$enroll_rate,
+    fail_rate = x$fail_rate,
+    test = wlr,
+    cut = list(ia1 = create_cut(planned_calendar_time = x$analysis$time[1]),
+               ia2 = create_cut(planned_calendar_time = x$analysis$time[2]),
+               fa = create_cut(planned_calendar_time = x$analysis$time[3])),
+    weight = fh(rho = 0, gamma = 0),
+    original_design = x
+  )
+
+  expect_equivalent(run1, run2[, colnames(run1)])
+
+  expected <- data.frame(
+    planed_upper_bound = c(3.870248012128966, 2.3566552618098884, 2.009757742407378),
+    planed_lower_bound = c(-1.705270817327003, 0.9601286375623664, 2.004752252887608),
+    updated_upper_bound = c(3.870248012128966, 2.3867954048423474, 2.0074221828251764),
+    updated_lower_bound = c(-1.6671962217546439, 0.9631736579151768, 2.1126105535696467)
+  )
+  observed <- run2[, c("planed_upper_bound", "planed_lower_bound",
+                       "updated_upper_bound", "updated_lower_bound")]
+  expect_equivalent(observed, expected)
 })


### PR DESCRIPTION
This is a follow-up to PR #324 which enabled updating the bounds in a simulation performed by `sim_gs_n()`.

1. First I added a test. I used the deprecated `expect_equivalent()` because we are still using {testthat} edition 2 (the replacement is only available with edition 3)
2. I replaced `dplyr::filter()` with `base::tapply()` and `dplyr::group_by()`+`dplyr::summarize()` with `base::tapply()`. Note that `tapply(summarize = TRUE)` returns a 1-D array, but this appears to be sufficient for our use case