### PR TITLE
Reduce runtime of sim_gs_n() examples

### DIFF
--- a/R/sim_gs_n.R
+++ b/R/sim_gs_n.R
@@ -137,6 +137,7 @@
 #'   weight = fh(rho = 0, gamma = 0)
 #' )
 #'
+#' \donttest{
 #' # Example 2: weighted logrank test by FH(0, 0.5) at all 3 analyses
 #' sim_gs_n(
 #'   n_sim = 3,
@@ -191,6 +192,7 @@
 #'   cut = list(ia1 = ia1_cut, ia2 = ia2_cut, fa = fa_cut),
 #'   ms_time = 10
 #' )
+#' }
 #'
 #' # Warning: this example will be executable when we add info info0 to the milestone test
 #' # Example 7: WLR with fh(0, 0.5) test at IA1,
@@ -238,6 +240,7 @@
 #' )
 #' }
 #'
+#' \donttest{
 #' # Example 9: regular logrank test at all 3 analyses in parallel
 #' plan("multisession", workers = 2)
 #' sim_gs_n(
@@ -265,6 +268,7 @@
 #'   weight = fh(rho = 0, gamma = 0),
 #'   original_design = x
 #' )
+#' }
 sim_gs_n <- function(
     n_sim = 1000,
     sample_size = 500,

--- a/man/sim_gs_n.Rd
+++ b/man/sim_gs_n.Rd
@@ -165,6 +165,7 @@ sim_gs_n(
   weight = fh(rho = 0, gamma = 0)
 )
 
+\donttest{
 # Example 2: weighted logrank test by FH(0, 0.5) at all 3 analyses
 sim_gs_n(
   n_sim = 3,
@@ -219,6 +220,7 @@ sim_gs_n(
   cut = list(ia1 = ia1_cut, ia2 = ia2_cut, fa = fa_cut),
   ms_time = 10
 )
+}
 
 # Warning: this example will be executable when we add info info0 to the milestone test
 # Example 7: WLR with fh(0, 0.5) test at IA1,
@@ -266,6 +268,7 @@ sim_gs_n(
 )
 }
 
+\donttest{
 # Example 9: regular logrank test at all 3 analyses in parallel
 plan("multisession", workers = 2)
 sim_gs_n(
@@ -293,5 +296,6 @@ sim_gs_n(
   weight = fh(rho = 0, gamma = 0),
   original_design = x
 )
+}
 \dontshow{\}) # examplesIf}
 }


### PR DESCRIPTION
From `R CMD check` on the latest commit https://github.com/Merck/simtrial/commit/99f1aedc3a4a3bacbc2cdb836d42d113833d1946 running on [Ubuntu with R-devel](https://github.com/Merck/simtrial/actions/runs/15328054977/job/43127527403#step:6:116):

```
* checking examples ... [34s/36s] OK
Examples with CPU (user + system) or elapsed time > 5s
           user system elapsed
sim_gs_n 15.684  0.388  17.764
* checking examples with --run-donttest ... [37s/41s] OK
```

To reduce the runtime, I used wrapped most of the tests in `\donttest{}` (which is what we previously did for `sim_fixed_n()` in https://github.com/Merck/simtrial/pull/177).