### PR TITLE
Install {parallelly} 1.44.0 for macOS

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,6 +44,13 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
+      - name: Install {parallelly} 1.44.0 for macOS
+        if: runner.os == 'macOS'
+        shell: Rscript {0}
+        run: |
+          install.packages("remotes")
+          remotes::install_version("parallelly", "1.44.0", upgrade = FALSE)
+
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true


### PR DESCRIPTION
Until we can find a longer-term solution, this PR fixes the macOS build by downgrading {parallelly} to 1.44.0.

xref: https://github.com/Merck/simtrial/issues/337, https://github.com/Merck/simtrial/pull/322