### PR TITLE
Install {parallelly} 1.45.1 for macOS

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,13 +44,6 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
 
-      - name: Install {parallelly} 1.44.0 for macOS
-        if: runner.os == 'macOS'
-        shell: Rscript {0}
-        run: |
-          install.packages("remotes")
-          remotes::install_version("parallelly", "1.44.0", upgrade = FALSE)
-
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true


### PR DESCRIPTION
Closes #337

The macOS-specific problem was fixed in [{parallelly 1.45.1}](https://github.com/futureverse/parallelly/blob/9e38aae1540fcea156c945bb95e0951c8833e5a2/NEWS.md#version-1451-2025-07-24), which was accepted on CRAN on 2025-07-24

xref: https://github.com/Merck/simtrial/pull/338, https://github.com/futureverse/doFuture/issues/87, https://github.com/futureverse/parallelly/commit/b26aef3ac4ea9c4d56e544eb3795fca940c21024