### PR TITLE
Fix a few typos in the documentation for sim_gs_n() and milestone()

### DIFF
--- a/R/milestone.R
+++ b/R/milestone.R
@@ -25,7 +25,7 @@
 #' @param ms_time Milestone analysis time.
 #' @param test_type Method to build the test statistics.
 #' There are 2 options:
-#'   - `"native"`: a native approach by dividing the KM survival difference by its standard derivations,
+#'   - `"naive"`: a naive approach by dividing the KM survival difference by its standard derivations,
 #'   see equation (1) of Klein, J. P., Logan, B., Harhoff, M., & Andersen, P. K. (2007).
 #'   - `"log-log"`: a log-log transformation of the survival, see equation (3) of
 #'   Klein, J. P., Logan, B., Harhoff, M., & Andersen, P. K. (2007).

--- a/R/sim_gs_n.R
+++ b/R/sim_gs_n.R
@@ -107,7 +107,7 @@
 #' # IA2
 #' # The 2nd interim analysis will occur at the later of the following 3 conditions:
 #' # - At least 32 months have passed since the start of the study.
-#' # - At least 250 events have occurred.
+#' # - At least 200 events have occurred.
 #' # - At least 10 months after IA1.
 #' # However, if events accumulation is slow, we will wait for a maximum of 34 months.
 #' ia2_cut <- create_cut(
@@ -120,7 +120,7 @@
 #' # FA
 #' # The final analysis will occur at the later of the following 2 conditions:
 #' # - At least 45 months have passed since the start of the study.
-#' # - At least 300 events have occurred.
+#' # - At least 350 events have occurred.
 #' fa_cut <- create_cut(
 #'   planned_calendar_time = 45,
 #'   target_event_overall = 350

--- a/man/milestone.Rd
+++ b/man/milestone.Rd
@@ -19,7 +19,7 @@ milestone(data, ms_time, test_type = c("log-log", "naive"))
 \item{test_type}{Method to build the test statistics.
 There are 2 options:
 \itemize{
-\item \code{"native"}: a native approach by dividing the KM survival difference by its standard derivations,
+\item \code{"naive"}: a naive approach by dividing the KM survival difference by its standard derivations,
 see equation (1) of Klein, J. P., Logan, B., Harhoff, M., & Andersen, P. K. (2007).
 \item \code{"log-log"}: a log-log transformation of the survival, see equation (3) of
 Klein, J. P., Logan, B., Harhoff, M., & Andersen, P. K. (2007).

--- a/man/sim_gs_n.Rd
+++ b/man/sim_gs_n.Rd
@@ -135,7 +135,7 @@ ia1_cut <- create_cut(
 # IA2
 # The 2nd interim analysis will occur at the later of the following 3 conditions:
 # - At least 32 months have passed since the start of the study.
-# - At least 250 events have occurred.
+# - At least 200 events have occurred.
 # - At least 10 months after IA1.
 # However, if events accumulation is slow, we will wait for a maximum of 34 months.
 ia2_cut <- create_cut(
@@ -148,7 +148,7 @@ ia2_cut <- create_cut(
 # FA
 # The final analysis will occur at the later of the following 2 conditions:
 # - At least 45 months have passed since the start of the study.
-# - At least 300 events have occurred.
+# - At least 350 events have occurred.
 fa_cut <- create_cut(
   planned_calendar_time = 45,
   target_event_overall = 350


### PR DESCRIPTION
Two changes:

* For the `sim_gs_n()` examples, I updated the comments to match the code
* For `milestone()`, I replaced "native" with "naive" after confirming that the [publication abstract](https://pubmed.ncbi.nlm.nih.gov/17348080/) used "naive"