### PR TITLE
Update signif digits for `sim_gs_n()` test to verify bounds from {gsDesign2}

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 ## Programming improvements
 
 - Added an internal helper function `cut_from_design()` to automatically generate cuttings based on the design object (#350, thanks to @yihui).
+- Updated significant digits required for `sim_gs_n()` test to verify the asymptotic theory from {gsDesign2} (#355, thanks to @jdblischak).
 
 # simtrial 1.0.1
 

--- a/tests/testthat/test-unvalidated-sim_gs_n.R
+++ b/tests/testthat/test-unvalidated-sim_gs_n.R
@@ -706,6 +706,12 @@ test_that("Updating bounds changes the simulation results", {
   )
   observed <- run2[, c("planned_upper_bound", "planned_lower_bound",
                        "updated_upper_bound", "updated_lower_bound")]
+
+  # Only need to test to 6 significant digits to verify the asymptotic theory
+  # from gsDesign2
+  expected <- lapply(expected, function(x) signif(x, digits = 6))
+  observed <- lapply(observed, function(x) signif(x, digits = 6))
+
   expect_equal(observed, expected, ignore_attr = TRUE)
 })
 


### PR DESCRIPTION
Closes #354

The bounds returned by {gsDesign2} changed slightly between versions [1.1.6 and 1.1.7](https://github.com/Merck/gsDesign2/compare/v1.1.6...v1.1.7). This PR relaxes the stringency of the test to 6 significant digits, which is sufficient to verify the asymptotic theory.