### PR TITLE
Remove roxygen2 messages caused by links to internal functions

### DIFF
--- a/R/pvalue_maxcombo.R
+++ b/R/pvalue_maxcombo.R
@@ -18,13 +18,13 @@
 
 #' MaxCombo p-value
 #'
-#' Computes p-values for the MaxCombo test based on output from [fh_weight()].
+#' Computes p-values for the MaxCombo test based on output from `fh_weight()`.
 #' This is still in an experimental stage and is intended for use with
 #' the [sim_fixed_n()] trial simulation routine.
 #' However, it can also be used to analyze clinical trial data such as
 #' that provided in the ADaM ADTTE format.
 #'
-#' @param z A dataset output from [fh_weight()]; see examples.
+#' @param z A dataset output from `fh_weight()`; see examples.
 #' @param algorithm This is passed directly to the `algorithm` argument
 #'   in [mvtnorm::pmvnorm()].
 #'


### PR DESCRIPTION
xref: https://github.com/Merck/simtrial/pull/351, https://github.com/Merck/gsDesign2/pull/601, https://github.com/Merck/simtrial/pull/227

After migrating to roxygen2 7.3.3, documenting the package produces the following verbose messages:

```R
══ Documenting ═════════════════════════════════════════════════════════════════
ℹ Updating simtrial documentation
ℹ Loading simtrial
✖ pvalue_maxcombo.R:21: @description Could not resolve link to topic
  "fh_weight" in the dependencies or base packages.
ℹ If you haven't documented "fh_weight" yet, or just changed its name, this is
  normal. Once "fh_weight" is documented, this warning goes away.
ℹ Make sure that the name of the topic is spelled correctly.
ℹ Always list the linked package as a dependency.
ℹ Alternatively, you can fully qualify the link with a package name.
✖ pvalue_maxcombo.R:27: @param Could not resolve link to topic "fh_weight" in
  the dependencies or base packages.
ℹ If you haven't documented "fh_weight" yet, or just changed its name, this is
  normal. Once "fh_weight" is documented, this warning goes away.
ℹ Make sure that the name of the topic is spelled correctly.
ℹ Always list the linked package as a dependency.
ℹ Alternatively, you can fully qualify the link with a package name.
```

Both `pvalue_maxcombo()` and `fh_weight()` are internal functions with the tag `@noRd`, and thus the roxygen2 cross-reference syntax is no longer useful (they were exported in the past but then un-exported). I removed the cross-references so that the distracting messages are no longer produced.