### PR TITLE
Install survMisc from GitHub since it was archived on CRAN

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: any::rcmdcheck, cran/survMisc
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, local::.
+          extra-packages: any::pkgdown, local::., cran/survMisc
           needs: website
 
       - name: Build site

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr, any::xml2
+          extra-packages: any::covr, any::xml2, cran/survMisc
           needs: coverage
 
       - name: Test coverage


### PR DESCRIPTION
## Summary
- survMisc was archived on CRAN, so `pak` can no longer install it from CRAN.
- Tests already use `skip_if_not_installed("survMisc")` to gracefully skip when unavailable.
- Install survMisc from the `cran/survMisc` GitHub mirror in CI workflows (R-CMD-check and test-coverage) via the `extra-packages` field.

## Test plan
- [ ] Verify R-CMD-check workflow passes with survMisc tests running
- [ ] Verify test-coverage workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)