### PR TITLE
Use dependabot to auto-update GitHub Actions versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "quarterly"


### PR DESCRIPTION
This PR enables the dependabot to automatically check for updated GitHub Actions versions every quarter and send PRs with any updates. This removes the burden from us to maintain up-to-date versions.

I mistakenly thought this had to be done via the repository Settings. But no, that just opens an editor in the UI to create the file `.github/dependabot.yml`. In other words, there is no advantage to that option compared to directly adding the file via a PR.

xref: https://github.com/Merck/simtrial/pull/362#pullrequestreview-4322149654

To learn more:

https://docs.github.com/en/code-security/tutorials/secure-your-dependencies/dependabot-quickstart-guide https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-dependabot-version-updates https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file