### PR TITLE
Fix test-coverage workflow inputs for codecov/codecov-action@v6

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -43,8 +43,8 @@ jobs:
         with:
           # Fail if error if not on PR, or if on PR and token is given
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
-          file: ./cobertura.xml
-          plugin: noop
+          files: ./cobertura.xml
+          plugins: noop
           disable_search: true
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
Follow up to #362. I had missed that `codecov/codecov-action@v6` updated the names of its inputs (https://github.com/r-lib/actions/pull/1057). And since this code is not run on a fork, it wasn't caught by the workflows triggered by the PR.