### PR TITLE
Harden summary.simtrial_gs_wlr() tests to upstream {gsDesign2} updates

### DIFF
--- a/tests/testthat/test-unvalidated-summary.R
+++ b/tests/testthat/test-unvalidated-summary.R
@@ -72,14 +72,14 @@ test_that("summary.simtrial_gs_wlr() returns consistent results for one-sided de
   observed <- simulation |> summary(design = design)
   expected <- data.frame(
     analysis = c(1, 2, 3),
-    asy_upper_prob = c(0.00014865936645545522, 0.5723215057363614, 0.9000000002116888),
+    asy_upper_prob = design$bound$probability,
     sim_upper_prob = c(NA, 1, NA),
     sim_event = c(97, 305, 405),
     sim_n = c(369.3333333333333, 505, 505),
     sim_time = c(12.877359569828519, 24.990283397668506, 37.20491262038222),
-    asy_time = c(12, 24, 36),
-    asy_n = c(353.04671034431556, 504.3524433490222, 504.3524433490222),
-    asy_event = c(96.77457617908364, 304.00996193840484, 404.14196474655887)
+    asy_time = design$analysis$time,
+    asy_n = design$analysis$n,
+    asy_event = design$analysis$event
   ) |>
     structure(
       class = c("simtrial_gs_wlr", "data.frame"),
@@ -162,16 +162,16 @@ test_that("summary.simtrial_gs_wlr() returns consistent results for two-sided de
   observed <- simulation |> summary(design = design)
   expected <- data.frame(
     analysis = c(1, 2, 3),
-    asy_upper_prob = c(0.00016250401737420353, 0.6011019363189855, 0.9000000001924918),
-    asy_lower_prob = c(0.0007883883873094952, 0.05707064419933058, 0.10004018006137042),
+    asy_upper_prob = design$bound$probability[design$bound$bound == "upper"],
+    asy_lower_prob = design$bound$probability[design$bound$bound == "lower"],
     sim_upper_prob = c(NA, 0.6666666666666666, 1),
     sim_lower_prob = rep(NA_real_, 3L),
     sim_event = c(103, 323, 429),
     sim_n = c(366.6666666666667, 535, 535),
     sim_time = c(12.363838412468121, 24.374413483785986, 36.116791896100885),
-    asy_time = c(12, 24, 36),
-    asy_n = c(374.08958620608826, 534.4136945801262, 534.4136945801262),
-    asy_event = c(102.54269505243633, 322.13006815203613, 428.2303047466704)
+    asy_time = design$analysis$time,
+    asy_n = design$analysis$n,
+    asy_event = design$analysis$event
   ) |>
     structure(
       compare_with_design = "yes",


### PR DESCRIPTION
My [scheduled integration check](https://github.com/jdblischak/gs-integration-tests/actions/runs/32704703024) identified two {simtrial} tests that fail with the development version of {gsDesign2}. This is because {gsDesign2} was recently updated to change how the futility bound is calculated for the final analysis (https://github.com/Merck/gsDesign2/pull/656).

One of the failing tests is for `sim_gs_n()` and one for `summary.simtrial_gs_wlr()`. This PR only fixes the latter:

```R
── Failure ('test-unvalidated-summary.R:182:3'): summary.simtrial_gs_wlr() returns consistent results for two-sided design ──
Expected `observed` to equal `expected`.
Differences:
actual vs expected
                asy_lower_prob
  actual[1, ]     0.0007883884
  actual[2, ]     0.0570706442
- actual[3, ]     0.1000001794
+ expected[3, ]   0.1000401801

  `actual$asy_lower_prob`: 0.0007884 0.0570706 0.1000002
`expected$asy_lower_prob`: 0.0007884 0.0570706 0.1000402
```

In general, I tried to make these tests more robust to upstream changes in {gsDesign2} by always pulling the expected values for the asymptotic results directly from the design object.