### PR TITLE
Remove archived {survMisc} from Suggests

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,8 +41,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, cran/survMisc
-          needs: check
+          extra-packages: any::rcmdcheck
+          needs: check, tests
 
       - uses: r-lib/actions/check-r-package@v2
         with:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::pkgdown, local::., cran/survMisc
+          extra-packages: any::pkgdown, local::.
           needs: website
 
       - name: Build site

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -25,8 +25,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr, any::xml2, cran/survMisc
-          needs: coverage
+          extra-packages: any::covr, any::xml2
+          needs: coverage, tests
 
       - name: Test coverage
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,7 +59,6 @@ Suggests:
     gt,
     knitr,
     rmarkdown,
-    survMisc,
     survRM2,
     testthat (>= 3.0.0),
     tibble,
@@ -69,3 +68,4 @@ LinkingTo:
 Roxygen: list(markdown = TRUE)
 Config/roxygen2/version: 8.1.0
 Config/testthat/edition: 3
+Config/Needs/tests: cran/survMisc


### PR DESCRIPTION
Close #359 

* The {survMisc} package continues to be archived on [CRAN](https://cran.r-project.org/package=survMisc), and no development has occurred in the upstream [repository](https://github.com/dardisco/survMisc) in years
* Our previous fix focused on the immediate problem of restoring our GitHub Actions pipelines (#361)
* But we will be unable to submit to CRAN as long as we have an archived package listed in Suggests, which I confirmed by submitting to winbuilder:
    ```
    Suggests or Enhances not in mainstream repositories:
      survMisc
    ```
* This PR attempts to enable a future CRAN submission while continuing to run the existing tests that require {survMisc} by using the `Config/Needs` approach of [{remotes}](https://remotes.r-lib.org/news/index.html?q=config/needs#new-functions-and-features-2-2-0), which is supported by [r-lib/actions/setup-r-dependencies](https://github.com/r-lib/actions/tree/v2-branch/setup-r-dependencies)
* I confirmed in GitHub Actions run on my fork that {survMisc} is installed, eg [here](https://github.com/jdblischak/simtrial/actions/runs/33411288338/job/99551202260#step:5:13993)

Thoughts on this approach? Does `Config/Needs/tests` work or should we choose a different designation?